### PR TITLE
Make sure single quotes become valid json

### DIFF
--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from tempfile import NamedTemporaryFile
@@ -132,7 +133,7 @@ class DeployToKubernetes(BaseKubernetes):
         """
         docker_credentials = DockerRegistry(self.vault_name, self.vault_client).credentials(self.config)
         return b64_encode(
-            str(
+            json.dumps(
                 {
                     "auths": {
                         docker_credentials.registry: {

--- a/tests/azure/test_deploy_kubernetes.py
+++ b/tests/azure/test_deploy_kubernetes.py
@@ -116,7 +116,7 @@ spec:
                 return_value=DockerCredentials("myuser", "secretpassword", "registry.io"))
     def test_get_docker_registry_secret(self, _, victim):
         result = victim._get_docker_registry_secret()
-        assert result == "eydhdXRocyc6IHsncmVnaXN0cnkuaW8nOiB7J3VzZXJuYW1lJzogJ215dXNlcicsICdwYXNzd29yZCc6ICdzZWNyZXRwYXNzd29yZCcsICdhdXRoJzogJ2JYbDFjMlZ5T25ObFkzSmxkSEJoYzNOM2IzSmsnfX19"
+        assert result == "eyJhdXRocyI6IHsicmVnaXN0cnkuaW8iOiB7InVzZXJuYW1lIjogIm15dXNlciIsICJwYXNzd29yZCI6ICJzZWNyZXRwYXNzd29yZCIsICJhdXRoIjogImJYbDFjMlZ5T25ObFkzSmxkSEJoYzNOM2IzSmsifX19"
 
     @pytest.mark.skip(reason="kubectl can't work without a valid kube context :(")
     @mock.patch("takeoff.azure.deploy_to_kubernetes.DockerRegistry.credentials",


### PR DESCRIPTION
## Summary:

Single quotes are not valid json. This makes sure python dicts become valid json.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] There is no commented out code in this PR.
  - [ ] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated
