### PR TITLE
Add ability to pass custom values to k8s jinja

### DIFF
--- a/docs/_deployment-steps/deploy_to_kubernetes.md
+++ b/docs/_deployment-steps/deploy_to_kubernetes.md
@@ -139,7 +139,8 @@ steps:
 
 Extended configuration example, where we have explicitly disabled the creation of kubernetes secrets by Takeoff. In this case,
 we also want to restart the resources, even if their Kubernetes yaml config is unchanged. It will also create image pull secrets in namespace `default` with name `registry-auth`.
-We also pass in a custom url value per environment in this example. 
+We also pass in a custom url value per environment in this example. In this case, we're using the default environment naming that Takeoff itself uses too. Please take a look at
+the [environment](../environment.md) docs for more information on how to define your own environment names.
 
 ```yaml
 steps:

--- a/docs/_deployment-steps/deploy_to_kubernetes.md
+++ b/docs/_deployment-steps/deploy_to_kubernetes.md
@@ -40,6 +40,7 @@ This should be after the [build_docker_image](build-docker-image) task if used t
 | `image_pull_secret.namespace` | The namespace where the secret should be created in | Default to `default` 
 | `restart_unchanged_resources` | Whether or not to restart unchanged Kubernetes resources. Takeoff will attempt to restart all unchanged resources, which may result in error messages in the 
  logs, as not all resources are 'restartable' | Boolean, defaults to False. | 
+| `custom_values` | Any custom values you'd like to pass in to be rendered into your Jinja-templates Kubernetes configuration. Should be specified per environment | No custom values are passed by default. Should be a set of key-value pairs per environment |
 
 
 An example of `kubernetes_config_path.yml.j2` 
@@ -82,6 +83,22 @@ spec:
   selector:
     app: my_app
   type: LoadBalancer
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: my-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: {{ url }}
+    http:
+      paths:
+      - path: /foo
+        backend:
+          serviceName: service1
+          servicePort: 4200
 ```
 
 An explanation for the Jinja templated values. These values get resolved automatically during deployment.
@@ -91,8 +108,11 @@ An explanation for the Jinja templated values. These values get resolved automat
 | ----- | ----------- 
 | `docker_tag` | The docker tag to apply. In a D/T/A/P setup, this will allow you to point to the image that was built in a previous step in your Takeoff config without explicitly specifying this
 
-Any other templated variable, such as `{{secret_pull_policy}}` is a reference to a cloud vault key. The task will pull all secrets from the cloud vault prefixed with you application name and resolve them in the template.
+Other templated variables can be filled in two ways:
+- Via your cloud keyvault, such as `{{secret_pull_policy}}` is a reference to a cloud vault key. The task will pull all secrets from the cloud vault prefixed with you application name and resolve them in the template.
 For the example above, if your application name is `myapp`, then a secret in your cloud vault must be `myapp-secret-pull-policy` or `myapp-secret_pull_policy`. The prefix gets removed by Takeoff and key `secret_pull_policy` with it's value will be passed into the template. Hyphens `-` get normalized to underscores `_`.
+- Via the `custom_values` configuration option specified in `deployment.yml`. Here, you are expected to set any custom key-value pairs, per environment. An example is shown below. In the above Kubernetes
+configuration, the `{{url}}` key is filled by a custom value passed in via `deployment.yml`.
 
 ## Takeoff config
 Make sure `.takeoff/config.yml` contains the following keys:
@@ -119,6 +139,7 @@ steps:
 
 Extended configuration example, where we have explicitly disabled the creation of kubernetes secrets by Takeoff. In this case,
 we also want to restart the resources, even if their Kubernetes yaml config is unchanged. It will also create image pull secrets in namespace `default` with name `registry-auth`.
+We also pass in a custom url value per environment in this example. 
 
 ```yaml
 steps:
@@ -126,6 +147,12 @@ steps:
   kubernetes_config_path: my_kubernetes_config.yml.j2
   image_pull_secret: 
     create: True
-    
   restart_unchanged_resources: true
+  custom_values:
+    dev:
+      url: 'dev-url-here-being-buggy'
+    acp:
+      url: 'acp-url-here-being-awesome'
+    prd:
+      url: 'prd-url-here-being-glorious'
 ```

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -93,7 +93,7 @@ DEPLOY_SCHEMA = TAKEOFF_BASE_SCHEMA.extend(
             vol.Optional("secret_name", default="registry-auth"): str,
             vol.Optional("namespace", default="default"): str,
         },
-        vol.Optional("custom_values"): {},
+        vol.Optional("custom_values", default={}): {},
         vol.Optional("restart_unchanged_resources", default=False): bool,
         "azure": {
             vol.Required(
@@ -246,7 +246,7 @@ class DeployToKubernetes(BaseKubernetes):
         )
 
     def _get_custom_values(self) -> Dict[str, str]:
-        if "custom_values" in self.config:
+        if self.config["custom_values"]:
             if self.env.environment in self.config["custom_values"]:
                 return self.config["custom_values"][self.env.environment]
             else:
@@ -254,7 +254,6 @@ class DeployToKubernetes(BaseKubernetes):
                     "No matching environment was found for custom values. Check your Takeoff config"
                     f"and your environment names. Looking for environment: {self.env.environment}"
                 )
-
         return {}
 
     def deploy_to_kubernetes(self, kubernetes_config_path: str, application_name: str):

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -93,6 +93,7 @@ DEPLOY_SCHEMA = TAKEOFF_BASE_SCHEMA.extend(
             vol.Optional("secret_name", default="registry-auth"): str,
             vol.Optional("namespace", default="default"): str,
         },
+        vol.Optional("custom_values"): {},
         vol.Optional("restart_unchanged_resources", default=False): bool,
         "azure": {
             vol.Required(

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -149,11 +149,21 @@ class DeployToKubernetes(BaseKubernetes):
         )
 
     def _render_kubernetes_config(
-        self, kubernetes_config_path: str, application_name: str, secrets: Dict[str, str]
+        self,
+        kubernetes_config_path: str,
+        application_name: str,
+        secrets: Dict[str, str],
+        custom_values: Dict[str, str],
     ) -> str:
         kubernetes_config = render_string_with_jinja(
             kubernetes_config_path,
-            {"docker_tag": self.env.artifact_tag, "application_name": application_name, **secrets},
+            {
+                "docker_tag": self.env.artifact_tag,
+                "application_name": application_name,
+                "env": self.env.environment,
+                **secrets,
+                **custom_values,
+            },
         )
         return kubernetes_config
 
@@ -165,7 +175,11 @@ class DeployToKubernetes(BaseKubernetes):
         return rendered_kubernetes_config_path.name
 
     def _render_and_write_kubernetes_config(
-        self, kubernetes_config_path: str, application_name: str, secrets: List[Secret]
+        self,
+        kubernetes_config_path: str,
+        application_name: str,
+        secrets: List[Secret],
+        custom_values: Dict[str, str],
     ) -> str:
         """
         Render the jinja-templated kubernetes configuration adn write it out to a temporary file.
@@ -177,7 +191,10 @@ class DeployToKubernetes(BaseKubernetes):
             The path to the temporary file where the rendered kubernetes configuration is stored.
         """
         kubernetes_config = self._render_kubernetes_config(
-            kubernetes_config_path, application_name, {_.key.replace("-", "_"): _.val for _ in secrets}
+            kubernetes_config_path,
+            application_name,
+            {_.key.replace("-", "_"): _.val for _ in secrets},
+            custom_values,
         )
         return self._write_kubernetes_config(kubernetes_config)
 
@@ -224,7 +241,20 @@ class DeployToKubernetes(BaseKubernetes):
                 Secret("namespace", self.config["image_pull_secret"]["namespace"]),
                 Secret("secret_name", self.config["image_pull_secret"]["secret_name"]),
             ],
+            custom_values={},
         )
+
+    def _get_custom_values(self) -> Dict[str, str]:
+        if "custom_values" in self.config:
+            if self.env.environment in self.config["custom_values"]:
+                return self.config["custom_values"][self.env.environment]
+            else:
+                raise ValueError(
+                    "No matching environment was found for custom values. Check your Takeoff config"
+                    f"and your environment names. Looking for environment: {self.env.environment}"
+                )
+
+        return {}
 
     def deploy_to_kubernetes(self, kubernetes_config_path: str, application_name: str):
         """Run a full deployment to Kubernetes, given configuration.
@@ -248,8 +278,10 @@ class DeployToKubernetes(BaseKubernetes):
             ApplicationName().get(self.config)
         )
 
+        custom_values = self._get_custom_values()
+
         rendered_kubernetes_config_path = self._render_and_write_kubernetes_config(
-            kubernetes_config_path, application_name, secrets
+            kubernetes_config_path, application_name, secrets, custom_values
         )
         logger.info("Kubernetes config rendered")
 

--- a/tests/azure/test_deploy_kubernetes.py
+++ b/tests/azure/test_deploy_kubernetes.py
@@ -87,7 +87,7 @@ metadata:
         m_write.assert_called_once_with(expected_result)
 
     def test_render_kubernetes_config(self, victim):
-        result = victim._render_kubernetes_config('tests/azure/files/valid_k8s.yml.j2', 'my-little-pony', {"secret_pull_policy": "Always"})
+        result = victim._render_kubernetes_config('tests/azure/files/valid_k8s.yml.j2', 'my-little-pony', {"secret_pull_policy": "Always"}, {})
 
         # we need this stupid formatting to make the test pass...
         expected_result = """apiVersion: extensions/v1beta1
@@ -129,6 +129,39 @@ spec:
         print(lines)
         assert code == 0
 
+    @mock.patch.dict(os.environ, env_variables)
+    @mock.patch("takeoff.step.KeyVaultClient.vault_and_client", return_value=(None, None))
+    def test_get_custom_values(self, _):
+        custom_conf = {'custom_values': {'dev': {'my_custom_value': 'hello'}}, **BASE_CONF}
+        conf = {**takeoff_config(), **custom_conf}
+        conf['azure'].update({"kubernetes_naming": "kubernetes{env}"})
+
+        res = DeployToKubernetes(ApplicationVersion("dev", "v", "branch"), conf)
+
+        result = res._get_custom_values()
+        expected_result = {"my_custom_value": "hello"}
+
+        assert result == expected_result
+
+    @mock.patch.dict(os.environ, env_variables)
+    @mock.patch("takeoff.step.KeyVaultClient.vault_and_client", return_value=(None, None))
+    def test_get_custom_values_missing_config(self, _, victim):
+        result = victim._get_custom_values()
+        expected_result = {}
+
+        assert result == expected_result
+
+    @mock.patch.dict(os.environ, env_variables)
+    @mock.patch("takeoff.step.KeyVaultClient.vault_and_client", return_value=(None, None))
+    def test_get_custom_values_invalid_env(self, _):
+        custom_conf = {'custom_values': {'invalid_env': {'my_custom_value': 'hello'}}, **BASE_CONF}
+        conf = {**takeoff_config(), **custom_conf}
+        conf['azure'].update({"kubernetes_naming": "kubernetes{env}"})
+
+        res = DeployToKubernetes(ApplicationVersion("dev", "v", "branch"), conf)
+
+        with pytest.raises(ValueError):
+            res._get_custom_values()
 
 @dataclass(frozen=True)
 class MockValue:


### PR DESCRIPTION
## Summary:
This will allow users to pass custom values into their Kubernetes Jinja
template via the Takeoff deployment.yml


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] There is no commented out code in this PR.
  - [ ] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated
