### PR TITLE
Fix base64 encoding of k8s templated values

### DIFF
--- a/docs/_deployment-steps/deploy_to_kubernetes.md
+++ b/docs/_deployment-steps/deploy_to_kubernetes.md
@@ -181,3 +181,16 @@ data:
 ```
 
 The jinja variables `entity1_connection_string` and `entity2_connection_string` are named by your `eventhub_entity_naming` in `create_producer_policies`, posfixed with `connection_string`.
+
+## Base64 encoding of secrets
+Kubernetes requires the values of secrets to be base64 encoded. Takeoff enables this, and by default takes the following approach:
+- Any values that are inserted into your Kubernetes template that originate from the *Keyvault* are assumed to be confidential. As such, Takeoff will ensure that these values
+are base64 encoded, as they should only be used in Kubernetes secrets.
+- Any values that are inserted into your Kubernetes template via the *custom values* support (i.e. that are supplied in Takeoff's deployment.yml) are assumed to __not__ be confidential. These
+values will therefore be inserted into the template in plain text.
+
+We believe these two assumptions are reasonable, and recommend you do not deviate from this. If, for some reason, you want/need to deviate from this, you can by using the following two filters in your Jinja template:
+- `b64_encode`: apply base64 encoding. Example usage: `{{ non_encoded_value |  b64_encode }}`
+- `b64_decode`: apply base64 decoding. Example usage: `{{ encoded_value |  b64_decode }}`
+
+TL;DR: secrets are base64 encoded by default, custom_values are not. You can deviate from this using the jinja2 filters if you like.

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -21,7 +21,7 @@ from takeoff.credentials.Secret import Secret
 from takeoff.credentials.application_name import ApplicationName
 from takeoff.schemas import TAKEOFF_BASE_SCHEMA
 from takeoff.step import Step
-from takeoff.util import render_string_with_jinja, b64_encode, run_shell_command
+from takeoff.util import b64_encode, ensure_base64, render_string_with_jinja, run_shell_command
 
 logger = logging.getLogger(__name__)
 
@@ -192,9 +192,10 @@ class DeployToKubernetes(BaseKubernetes):
         Returns:
             The path to the temporary file where the rendered kubernetes configuration is stored.
         """
-        vault_values = {_.jinja_safe_key: _.val for _ in secrets}
+        vault_values = {_.jinja_safe_key: ensure_base64(_.val) for _ in secrets}
+
         context_values = {
-            _.jinja_safe_key: b64_encode(_.val)
+            _.jinja_safe_key: ensure_base64(_.val)
             for _ in Context().get_or_else(ContextKey.EVENTHUB_PRODUCER_POLICY_SECRETS, {})
         }
 
@@ -241,12 +242,11 @@ class DeployToKubernetes(BaseKubernetes):
         return self._render_and_write_kubernetes_config(
             kubernetes_config_path=pull_secrets_yaml,
             application_name=application_name,
-            secrets=[
-                Secret("pull_secret", self._get_docker_registry_secret()),
-                Secret("namespace", self.config["image_pull_secret"]["namespace"]),
-                Secret("secret_name", self.config["image_pull_secret"]["secret_name"]),
-            ],
-            custom_values={},
+            secrets=[Secret("pull_secret", self._get_docker_registry_secret())],
+            custom_values={
+                "namespace": Secret("namespace", self.config["image_pull_secret"]["namespace"]).val,
+                "secret_name": Secret("secret_name", self.config["image_pull_secret"]["secret_name"]).val,
+            },
         )
 
     def _get_custom_values(self) -> Dict[str, str]:

--- a/takeoff/util.py
+++ b/takeoff/util.py
@@ -8,10 +8,11 @@ from dataclasses import dataclass
 from typing import Callable, List, Pattern, Union, Tuple
 
 from git import Repo
-from jinja2 import Template
+import jinja2
 from yaml import load
 
 logger = logging.getLogger(__name__)
+
 
 DEFAULT_TAKEOFF_PLUGIN_PREFIX = "takeoff_"
 
@@ -34,7 +35,7 @@ def render_string_with_jinja(path: str, params: dict) -> str:
         str: rendered jinja template as a string
     """
     with open(path) as file_:
-        template = Template(file_.read())
+        template = jinja2.Template(file_.read())
     rendered = template.render(**params)
     return rendered
 
@@ -77,6 +78,53 @@ def b64_encode(s: str) -> str:
         str: base64 encoded string
     """
     return base64.b64encode(s.encode()).decode()
+
+
+def b64_decode(s: str) -> str:
+    """Decode a given base64-encoded string
+
+    Args:
+        s: base64 encoded string to decode
+
+    Returns:
+        str: base64 decoded string
+    """
+    return base64.b64decode(s).decode()
+
+
+# register as a jinja2 filter to allow usage within jinja2 templates
+jinja2.filters.FILTERS["b64_encode"] = b64_encode
+jinja2.filters.FILTERS["b64_decode"] = b64_decode
+
+
+def is_base64(target: Union[str, bytes]) -> bool:
+    """Determines whether a given target (either bytes or string) is base64 encoded
+    Courtesy of
+    https://stackoverflow.com/questions/12315398/verify-is-a-string-is-encoded-in-base64-python
+
+    Args:
+        target: str/bytes to check for base64 encoding
+
+    Returns:
+        bool: true if target is base64 encoded
+    """
+    try:
+        if isinstance(target, str):
+            # If there's any unicode here, an exception will be thrown and the function will return false
+            target_bytes = bytes(target, "ascii")
+        elif isinstance(target, bytes):
+            target_bytes = target
+        else:
+            raise ValueError("Argument must be string or bytes")
+        return base64.b64encode(base64.b64decode(target_bytes)) == target_bytes
+    except Exception:
+        return False
+
+
+def ensure_base64(s: str) -> str:
+    if not is_base64(s):
+        return b64_encode(s)
+    return s
 
 
 def get_matching_group(find_in: str, pattern: Pattern[str], group: int):

--- a/tests/azure/test_deploy_kubernetes.py
+++ b/tests/azure/test_deploy_kubernetes.py
@@ -67,7 +67,7 @@ class TestDeployToKubernetes(object):
         assert res.config['kubernetes_config_path'] == "kubernetes_config/k8s.yml.j2"
 
     @mock.patch.dict(os.environ, env_variables)
-    @mock.patch("takeoff.azure.deploy_to_kubernetes.DeployToKubernetes._get_docker_registry_secret", return_value="somebase64encodedstring")
+    @mock.patch("takeoff.azure.deploy_to_kubernetes.DeployToKubernetes._get_docker_registry_secret", return_value="nonbase64encodedstring")
     def test_create_docker_registry_secret(self, _, victim):
         Context().clear()
         with mock.patch("takeoff.azure.deploy_to_kubernetes.DeployToKubernetes._write_kubernetes_config") as m_write:
@@ -82,7 +82,7 @@ kind: Secret
 apiVersion: v1
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: somebase64encodedstring
+  .dockerconfigjson: bm9uYmFzZTY0ZW5jb2RlZHN0cmluZw==
 metadata:
   name: registry-auth
   namespace: default"""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -47,3 +47,29 @@ class TestPatternMatching(object):
         filename = "my_stupid_file"
         with pytest.raises(FileNotFoundError):
             victim.get_full_yaml_filename(filename)
+
+
+def test_is_base64_valid_string():
+    assert victim.is_base64("c29tZXRoaW5n")
+
+
+def test_is_base_64_invalid_string():
+    assert not victim.is_base64("something")
+
+
+def test_is_base64_valid_bytes():
+    assert victim.is_base64(b'c29tZXRoaW5n')
+
+
+def test_is_base64_invalid_bytes():
+    assert not victim.is_base64(b'c29tZXRoaW5')
+
+
+def test_ensure_base64_non_encoded():
+    result = victim.ensure_base64("something")
+    assert result == "c29tZXRoaW5n"
+
+
+def test_ensure_base64_encoded():
+    result = victim.ensure_base64("c29tZXRoaW5n")
+    assert result == "c29tZXRoaW5n"


### PR DESCRIPTION
## Summary:
Until now, Takeoff made some assumptions regarding base64 encoding,
which in some cases led to awkward situations. The best example was
that in order to render a value from Azure Keyvault into the value of a
Kubernetes secret, the value in the Azure Keyvault would need to be
base64 encoded. 

This commit makes 2 general assumptions:
- template values that are fetched from the keyvault are to be base64
encoded, as they are secret.
- custom values that are provided via Takeoff config are not to be
base64 encoded, as they are already in plain text in deployment.yml

In order to allow maximum flexibility, a set of custom jinja2 filters is also
added, that allows users to deviate from the assumptions mentioned
above, by enforcing base64 encoding or decoding in the kubernetes
configuration. This option should be used with a lot of care, as it
could result in leaking secrets.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
