### PR TITLE
Revert back to separate takeoff docker builders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,12 @@ jobs:
       - checkout
       - run: env | grep -v ^PATH > .env
       - run: docker build -t takeoff:latest -f Dockerfile .
-      - run: docker run --env-file .env -v `echo $PWD`:/src -v /var/run/docker.sock:/var/run/docker.sock takeoff:latest takeoff
+      - run:
+          command: |
+            echo $REGISTRY_PASSWORD | docker login --username $REGISTRY_USER --password-stdin
+            version=$(docker run --env-file .env -v `echo $PWD`:/src takeoff:latest get_version)
+            docker tag takeoff:latest schipholhub/takeoff:${version}
+            docker push schipholhub/takeoff:${version}
 
 workflows:
   version: 2.1


### PR DESCRIPTION
For some reason building takeoff with takeoff itself isn't working. For now, reverting back to building Docker images in CI natively while we debug the problems on a branch.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] There is no commented out code in this PR.
  - [ ] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated
