### PR TITLE
Fix broken links in github pages docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 name: Schiphol Takeoff
 
 project:
-  version: 9.0.1 # TODO: this needs fixing
+  version: 2.0.2
   github: https://github.com/schipholgroup/takeoff
 
 markdown: kramdown

--- a/docs/deployment_steps.md
+++ b/docs/deployment_steps.md
@@ -11,7 +11,7 @@ permalink: deployment-steps
 <ul>
     {% for step in group.items %}
         <li>
-            <a href="takeoff{{ step.url }}">{{ step.title }}</a> <br>
+            <a href="{{ step.url | relative_url }}">{{ step.title }}</a> <br>
             <i> {{ step.summary }} </i>
         </li>
     {% endfor %}

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,7 +7,7 @@ permalink: getting-started
 
 # Getting started
 
-The easiest way to use Takeoff for your project is to use the prebuilt Docker image available [here](DOCKERHUB LINK). Using this prebuilt image, you'll
+The easiest way to use Takeoff for your project is to use the prebuilt Docker image available [here](https://hub.docker.com/r/schipholhub/takeoff). Using this prebuilt image, you'll
 need to add 2 additional files to your project in order for Runway to function correctly.
 
 ## Takeoff Files
@@ -91,7 +91,7 @@ using Gitlab CI:
 `.gitlab-ci.yml`
 ```yaml
 runway:
-  image: <<<DOCKERHUBLINKHERE>>>/takeoff:<<<VERSION_HERE>>>
+  image: schipholhub/takeoff:2.0.2
   variables:
     DOCKER_HOST: tcp://localhost:2375
   stage: deploy


### PR DESCRIPTION
## Summary:

This fixes a few broken links in the Github Pages docs, as per #34 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
