### PR TITLE
Push latest + make tests OS agnostic

### DIFF
--- a/docs/_deployment-steps/build_docker_image.md
+++ b/docs/_deployment-steps/build_docker_image.md
@@ -22,7 +22,9 @@ Add the following task to `deployment.yaml`
 | `dockerfiles` [optional]| List of more specific Docker file configurations. Consisting of:
 | `dockerfiles[].file` [optional] | Alternative Docker file name
 | `dockerfiles[].postfix` [optional] | Postfix for the image name, will be added before the tag
+| `dockerfiles[].prefix` [optional] | Prefix for the image name, will be added `between` the image name and repository (e.g. myreg.io/prefix/my-app:tag"
 | `dockerfiles[].custom_image_name` [optional] | A custom name for the image to be used
+| `dockerfiles[].tag_release_as_latest` [optional] | Tag a release also as 'latest' image. | Defaults to `true`
 
 ## Takeoff config
 Credentials for a Docker registry (username, password, registry) must be available in your cloud vault. Also, the [Docker cli](https://docs.docker.com/engine/reference/commandline/cli/) must be available. 
@@ -49,7 +51,7 @@ steps:
   - task: build_docker_image
 ```
 
-Full configuration example. This builds and pushed two Docker images to `acr.azurecr.io/myimage-one:1.2.0` (from `Dockerfile_one`) and `acr.azurecr.io/myapp:1.2.0` (from `Dockerfile_two`) respectively
+Full configuration example. This builds and pushed two Docker images to `acr.azurecr.io/myproject/myimage-one:1.2.0` (from `Dockerfile_one`) and `acr.azurecr.io/myapp:1.2.0` (from `Dockerfile_two`) respectively
 
 ```
 steps:
@@ -57,6 +59,7 @@ steps:
     dockerfile:
       - file: Dockerfile_one
         postfix: "-one"
+        prefix: "myproject"
         custom_image_name: myimage
       - file: Dockerfile_two
 ```

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as f:
 All setup dependencies are installed in the base docker image, removing the need to reinstall the same
 dependencies every CI run.
 Feel free to add missing ones to the dependencies here. As soon as these are stable move them to
-https://github.com/Schiphol-Hub/takeoff-base
+https://github.com/schipholgroup/takeoff-base
 """
 setup_dependencies = [
     "azure==4.0.0",
@@ -40,8 +40,8 @@ elif {"lint", "flake8"}.intersection(sys.argv):
 
 setup(
     name="Takeoff",
-    description="A package to bundle deployment scripts for Microsoft Azure",
-    author="Schiphol Data Hub",
+    description="A package to bundle deployment scripts for deploying application in the cloud",
+    author="Schiphol Group",
     long_description=long_description,
     author_email="SDH-Support@schiphol.nl",
     packages=find_packages(exclude=("tests*",)),

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -49,7 +49,7 @@ class BaseKubernetes(Step):
         """
         kubeconfig = credential_results.kubeconfigs[0].value.decode(encoding="UTF-8")
 
-        kubeconfig_dir = os.path.join(os.environ['HOME'], ".kube")
+        kubeconfig_dir = os.path.join(os.environ["HOME"], ".kube")
 
         # assumption here that there is no existing kubeconfig (which makes sense, given this script should
         # be run in a docker container ;-) )
@@ -154,11 +154,11 @@ class DeployToKubernetes(BaseKubernetes):
         )
 
     def _render_kubernetes_config(
-            self,
-            kubernetes_config_path: str,
-            application_name: str,
-            secrets: Dict[str, str],
-            custom_values: Dict[str, str],
+        self,
+        kubernetes_config_path: str,
+        application_name: str,
+        secrets: Dict[str, str],
+        custom_values: Dict[str, str],
     ) -> str:
         kubernetes_config = render_string_with_jinja(
             kubernetes_config_path,
@@ -180,11 +180,11 @@ class DeployToKubernetes(BaseKubernetes):
         return rendered_kubernetes_config_path.name
 
     def _render_and_write_kubernetes_config(
-            self,
-            kubernetes_config_path: str,
-            application_name: str,
-            secrets: List[Secret],
-            custom_values: Dict[str, str],
+        self,
+        kubernetes_config_path: str,
+        application_name: str,
+        secrets: List[Secret],
+        custom_values: Dict[str, str],
     ) -> str:
         """
         Render the jinja-templated kubernetes configuration adn write it out to a temporary file.

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -49,12 +49,12 @@ class BaseKubernetes(Step):
         """
         kubeconfig = credential_results.kubeconfigs[0].value.decode(encoding="UTF-8")
 
-        kubeconfig_dir = os.path.expanduser("~/.kube")
+        kubeconfig_dir = os.path.join(os.environ['HOME'], ".kube")
 
         # assumption here that there is no existing kubeconfig (which makes sense, given this script should
         # be run in a docker container ;-) )
         os.mkdir(kubeconfig_dir)
-        with open(kubeconfig_dir + "/config", "w") as f:
+        with open(os.path.join(kubeconfig_dir, "config"), "w") as f:
             f.write(kubeconfig)
 
         logger.info("Kubeconfig successfully written")
@@ -154,11 +154,11 @@ class DeployToKubernetes(BaseKubernetes):
         )
 
     def _render_kubernetes_config(
-        self,
-        kubernetes_config_path: str,
-        application_name: str,
-        secrets: Dict[str, str],
-        custom_values: Dict[str, str],
+            self,
+            kubernetes_config_path: str,
+            application_name: str,
+            secrets: Dict[str, str],
+            custom_values: Dict[str, str],
     ) -> str:
         kubernetes_config = render_string_with_jinja(
             kubernetes_config_path,
@@ -180,11 +180,11 @@ class DeployToKubernetes(BaseKubernetes):
         return rendered_kubernetes_config_path.name
 
     def _render_and_write_kubernetes_config(
-        self,
-        kubernetes_config_path: str,
-        application_name: str,
-        secrets: List[Secret],
-        custom_values: Dict[str, str],
+            self,
+            kubernetes_config_path: str,
+            application_name: str,
+            secrets: List[Secret],
+            custom_values: Dict[str, str],
     ) -> str:
         """
         Render the jinja-templated kubernetes configuration adn write it out to a temporary file.

--- a/takeoff/build_docker_image.py
+++ b/takeoff/build_docker_image.py
@@ -22,12 +22,16 @@ SCHEMA = TAKEOFF_BASE_SCHEMA.extend(
             str, vol.In(["environment_variables", "azure_keyvault"])
         ),
         vol.Optional(
-            "dockerfiles", default=[{"file": "Dockerfile",
-                                     "postfix": None,
-                                     "prefix": None,
-                                     "custom_image_name": None,
-                                     "tag_release_as_latest": True
-                                     }]
+            "dockerfiles",
+            default=[
+                {
+                    "file": "Dockerfile",
+                    "postfix": None,
+                    "prefix": None,
+                    "custom_image_name": None,
+                    "tag_release_as_latest": True,
+                }
+            ],
         ): [
             {
                 vol.Optional("file", default="Dockerfile", description="Alternative docker file name"): str,

--- a/takeoff/build_docker_image.py
+++ b/takeoff/build_docker_image.py
@@ -22,7 +22,12 @@ SCHEMA = TAKEOFF_BASE_SCHEMA.extend(
             str, vol.In(["environment_variables", "azure_keyvault"])
         ),
         vol.Optional(
-            "dockerfiles", default=[{"file": "Dockerfile", "postfix": None, "custom_image_name": None}]
+            "dockerfiles", default=[{"file": "Dockerfile",
+                                     "postfix": None,
+                                     "prefix": None,
+                                     "custom_image_name": None,
+                                     "tag_release_as_latest": True
+                                     }]
         ): [
             {
                 vol.Optional("file", default="Dockerfile", description="Alternative docker file name"): str,

--- a/takeoff_plugins/__init__.py
+++ b/takeoff_plugins/__init__.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def deploy_env_logic(config: dict) -> ApplicationVersion:
-    branch = BranchName(config, None).get()
+    branch = BranchName(config).get()
     tag = get_tag()
 
     if tag:

--- a/tests/azure/test_deploy_kubernetes.py
+++ b/tests/azure/test_deploy_kubernetes.py
@@ -69,7 +69,8 @@ class TestDeployToKubernetes(object):
         assert res.config['kubernetes_config_path'] == "kubernetes_config/k8s.yml.j2"
 
     @mock.patch.dict(os.environ, env_variables)
-    @mock.patch("takeoff.azure.deploy_to_kubernetes.DeployToKubernetes._get_docker_registry_secret", return_value="nonbase64encodedstring")
+    @mock.patch("takeoff.azure.deploy_to_kubernetes.DeployToKubernetes._get_docker_registry_secret",
+                return_value="nonbase64encodedstring")
     def test_create_docker_registry_secret(self, _, victim):
         Context().clear()
         with mock.patch("takeoff.azure.deploy_to_kubernetes.DeployToKubernetes._write_kubernetes_config") as m_write:
@@ -91,7 +92,8 @@ metadata:
         m_write.assert_called_once_with(expected_result)
 
     def test_render_kubernetes_config(self, victim):
-        result = victim._render_kubernetes_config('tests/azure/files/valid_k8s.yml.j2', 'my-little-pony', {"secret_pull_policy": "Always"}, {})
+        result = victim._render_kubernetes_config('tests/azure/files/valid_k8s.yml.j2', 'my-little-pony',
+                                                  {"secret_pull_policy": "Always"}, {})
 
         # we need this stupid formatting to make the test pass...
         expected_result = """apiVersion: extensions/v1beta1
@@ -167,6 +169,7 @@ spec:
         with pytest.raises(ValueError):
             res._get_custom_values()
 
+
 @dataclass(frozen=True)
 class MockValue:
     value: bytes
@@ -185,6 +188,6 @@ class TestBaseKubernetes():
             with mock.patch("builtins.open", mopen):
                 victim._write_kube_config(MockCredentialResults([MockValue("foo".encode(encoding="UTF-8"))]))
 
-        m_mkdir.assert_called_once_with("myhome/.kube")
-        mopen.assert_called_once_with("myhome/.kube/config", "w")
+        m_mkdir.assert_called_once_with(os.path.join("myhome", ".kube"))
+        mopen.assert_called_once_with(os.path.join("myhome", ".kube", "config"), "w")
         mopen().write.assert_called_once_with("foo")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import pytest
@@ -40,7 +41,7 @@ class TestPatternMatching(object):
     def test_get_full_yaml_filename_file_exists(self):
         filename = "deployment"
         result = victim.get_full_yaml_filename(filename)
-        expected_result = ".takeoff/deployment.yml"
+        expected_result = os.path.join(".takeoff", "deployment.yml")
         assert result == expected_result
 
     def test_get_full_yaml_filename_file_not_exists(self):


### PR DESCRIPTION
## Summary:

- Allows an option that pushes release docker images also as `latest`. Default is set to `true`.
- Allow unit tests and some pieces of code to be OS independent.

closes #18 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR
