### PR TITLE
Stop running takeoff on branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,5 +88,7 @@ workflows:
             - typecheck
             - test
           filters:
+            branches:
+              only: master
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
## Summary:

This somehow slipped through, we only want to run takeoff on master and
on tags.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] There is no commented out code in this PR.
  - [ ] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated
