### PR TITLE
add environment as an argument to the DBricks job config

### DIFF
--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -102,7 +102,7 @@ class DeployToDatabricks(Step):
             log_destination=job_name,
             parameters=self._construct_arguments(job_config["arguments"]),
             schedule=self._get_schedule(job_config),
-            environment=self.env.environment.lower(),
+            environment=self.env.environment_formatted,
         )
 
         root_library_folder = self.config["common"]["databricks_fs_libraries_mount_path"]

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -102,7 +102,7 @@ class DeployToDatabricks(Step):
             log_destination=job_name,
             parameters=self._construct_arguments(job_config["arguments"]),
             schedule=self._get_schedule(job_config),
-            environment=self.env.environment.lower()
+            environment=self.env.environment.lower(),
         )
 
         root_library_folder = self.config["common"]["databricks_fs_libraries_mount_path"]

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -102,6 +102,7 @@ class DeployToDatabricks(Step):
             log_destination=job_name,
             parameters=self._construct_arguments(job_config["arguments"]),
             schedule=self._get_schedule(job_config),
+            environment=self.env.environment.lower()
         )
 
         root_library_folder = self.config["common"]["databricks_fs_libraries_mount_path"]


### PR DESCRIPTION
## Summary:

Adding extra parameter to DataBricks config file so that we will have the option to change the configuration values depending on the environment the job will run (such as `instance_pool_id`)

## Breaking Change:

None breaking change expected

## Checklist:
  - [-] The code change is tested and works locally.
  - [+] There is no commented out code in this PR.
  - [+] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [ ] Not yet.
