### PR TITLE
Fix job deletion for named jobs

### DIFF
--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -89,7 +89,7 @@ class DeployToDatabricks(Step):
             is_streaming = self._job_is_streaming(job_config)
 
             logger.info("Removing old job")
-            self.remove_job(self.env.artifact_tag, is_streaming=is_streaming)
+            self.remove_job(self.env.artifact_tag, job_config=job, is_streaming=is_streaming)
 
             logger.info("Submitting new job with configuration:")
             logger.info(pprint.pformat(job_config))
@@ -149,7 +149,7 @@ class DeployToDatabricks(Step):
     def _construct_job_config(config_file: str, **kwargs) -> dict:
         return util.render_file_with_jinja(config_file, kwargs, json.loads)
 
-    def remove_job(self, branch: str, is_streaming: bool):
+    def remove_job(self, branch: str, job_config: dict, is_streaming: bool):
         """
         Removes the existing job and cancels any running job_run if the application is streaming.
         If the application is batch, it'll let the batch job finish but it will remove the job,
@@ -159,7 +159,7 @@ class DeployToDatabricks(Step):
         job_configs = [
             JobConfig(_["settings"]["name"], _["job_id"]) for _ in self.jobs_api.list_jobs()["jobs"]
         ]
-        job_ids = self._application_job_id(self.application_name, branch, job_configs)
+        job_ids = self._application_job_id(self._construct_name(job_config['name']), branch, job_configs)
 
         if not job_ids:
             logger.info(f"Could not find jobs in list of {pprint.pformat(job_configs)}")

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -159,7 +159,7 @@ class DeployToDatabricks(Step):
         job_configs = [
             JobConfig(_["settings"]["name"], _["job_id"]) for _ in self.jobs_api.list_jobs()["jobs"]
         ]
-        job_ids = self._application_job_id(self._construct_name(job_config['name']), branch, job_configs)
+        job_ids = self._application_job_id(self._construct_name(job_config["name"]), branch, job_configs)
 
         if not job_ids:
             logger.info(f"Could not find jobs in list of {pprint.pformat(job_configs)}")

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -557,11 +557,16 @@ class TestDeployToDatabricks(object):
                 "takeoff.azure.deploy_to_databricks.DeployToDatabricks._application_job_id",
                 return_value=["id1", "id2"],
         ):
-            victim.remove_job("my-branch", False)
+            victim.remove_job("my-branch", {'name': ""}, False)
 
         calls = [mock.call("id1"), mock.call("id2")]
 
         victim.jobs_api.delete_job.assert_has_calls(calls)
+
+    def test_remove_job_batch_with_name(self):
+        res = DeployToDatabricks._application_job_id("tim-postfix", "master", jobs)
+
+        assert len(res) == 2
 
     def test_remove_job_streaming(self, victim):
         with mock.patch(
@@ -571,7 +576,7 @@ class TestDeployToDatabricks(object):
             with mock.patch(
                     "takeoff.azure.deploy_to_databricks.DeployToDatabricks._kill_it_with_fire"
             ) as kill_mock:
-                victim.remove_job("my-branch", True)
+                victim.remove_job("my-branch", {'name': ""}, True)
 
         calls = [mock.call("id1"), mock.call("id2")]
 
@@ -583,7 +588,7 @@ class TestDeployToDatabricks(object):
                 "takeoff.azure.deploy_to_databricks.DeployToDatabricks._application_job_id",
                 return_value=[],
         ):
-            victim.remove_job("my-branch", False)
+            victim.remove_job("my-branch", {'name': ""}, False)
 
         victim.jobs_api.delete_job.assert_not_called()
 


### PR DESCRIPTION
## Summary:

Allows for older jobs with custom names to be deleted in Databricks.

Fix #48 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated
