### PR TITLE
Make multiple k8s tasks possible

### DIFF
--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -51,9 +51,9 @@ class BaseKubernetes(Step):
 
         kubeconfig_dir = os.path.join(os.environ["HOME"], ".kube")
 
-        # assumption here that there is no existing kubeconfig (which makes sense, given this script should
-        # be run in a docker container ;-) )
-        os.mkdir(kubeconfig_dir)
+        if not os.path.isdir(kubeconfig_dir):
+            os.mkdir(kubeconfig_dir)
+
         with open(os.path.join(kubeconfig_dir, "config"), "w") as f:
             f.write(kubeconfig)
 

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -52,8 +52,7 @@ class BaseKubernetes(Step):
 
         kubeconfig_dir = Path(os.environ["HOME"]) / ".kube"
 
-        if not kubeconfig_dir.is_dir():
-            kubeconfig_dir.mkdir()
+        kubeconfig_dir.mkdir(exist_ok=True)
 
         with open(kubeconfig_dir / "config", "w") as f:
             f.write(kubeconfig)

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List, Dict
 
@@ -49,12 +50,12 @@ class BaseKubernetes(Step):
         """
         kubeconfig = credential_results.kubeconfigs[0].value.decode(encoding="UTF-8")
 
-        kubeconfig_dir = os.path.join(os.environ["HOME"], ".kube")
+        kubeconfig_dir = Path(os.environ["HOME"]) / ".kube"
 
-        if not os.path.isdir(kubeconfig_dir):
-            os.mkdir(kubeconfig_dir)
+        if not kubeconfig_dir.is_dir():
+            kubeconfig_dir.mkdir()
 
-        with open(os.path.join(kubeconfig_dir, "config"), "w") as f:
+        with open(kubeconfig_dir / "config", "w") as f:
             f.write(kubeconfig)
 
         logger.info("Kubeconfig successfully written")

--- a/tests/azure/test_deploy_kubernetes.py
+++ b/tests/azure/test_deploy_kubernetes.py
@@ -189,6 +189,6 @@ class TestBaseKubernetes():
             with mock.patch("builtins.open", mopen):
                 victim._write_kube_config(MockCredentialResults([MockValue("foo".encode(encoding="UTF-8"))]))
 
-        m_mkdir.assert_called_once_with()
+        m_mkdir.assert_called_once_with(exist_ok=True)
         mopen.assert_called_once_with(Path("myhome", ".kube", "config"), "w")
         mopen().write.assert_called_once_with("foo")

--- a/tests/azure/test_deploy_kubernetes.py
+++ b/tests/azure/test_deploy_kubernetes.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List
 from unittest import mock
 
@@ -184,10 +185,10 @@ class TestBaseKubernetes():
     @mock.patch.dict(os.environ, {"HOME": "myhome"})
     def test_write_kube_config(self, victim: BaseKubernetes):
         mopen = mock.mock_open()
-        with mock.patch("os.mkdir") as m_mkdir:
+        with mock.patch("pathlib.Path.mkdir") as m_mkdir:
             with mock.patch("builtins.open", mopen):
                 victim._write_kube_config(MockCredentialResults([MockValue("foo".encode(encoding="UTF-8"))]))
 
-        m_mkdir.assert_called_once_with(os.path.join("myhome", ".kube"))
-        mopen.assert_called_once_with(os.path.join("myhome", ".kube", "config"), "w")
+        m_mkdir.assert_called_once_with()
+        mopen.assert_called_once_with(Path("myhome", ".kube", "config"), "w")
         mopen().write.assert_called_once_with("foo")


### PR DESCRIPTION
## Summary:
Until now, the assumption was that the .kube config directory did not exist, because
takeoff was (usually) being run in a docker container. Although this is true, it made it
impossible to run multiple deploy_to_kubernetes tasks, as the directory was created in
the first task execution, and threw an error in the second. This change only creates the
.kube directory in the container if it does not already exist

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] There is no commented out code in this PR.
  - [ ] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated
