### PR TITLE
Use SafeLoader with yaml.load()

### DIFF
--- a/takeoff/util.py
+++ b/takeoff/util.py
@@ -9,7 +9,7 @@ from typing import Callable, List, Pattern, Union, Tuple
 
 import jinja2
 from git import Repo
-from yaml import load
+from yaml import load, SafeLoader
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +150,7 @@ def has_prefix_match(find_in: str, to_find: str, pattern: Pattern[str]):
 def load_yaml(path: str) -> dict:
     with open(path, "r") as f:
         config_file = f.read()
-    return load(config_file)
+    return load(config_file, Loader=SafeLoader)
 
 
 def current_filename(__fn):


### PR DESCRIPTION
## Summary:

Per [this](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation):

>Use of PyYAML's yaml.load function without specifying the Loader=... parameter, has been deprecated.
>Before PyYAML 5.1, the PyYAML.load function could be easily exploited to call any Python function.

This PR replaces the naked `yaml.load(input)` call with `yaml.load(input, Loader=SafeLoader)`.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated
