### PR TITLE
Add optional CLI parameter to set takeoff path

### DIFF
--- a/docs/takeoff_config.md
+++ b/docs/takeoff_config.md
@@ -8,6 +8,11 @@ permalink: takeoff-config
 # Overview
 The `.takeoff/config.yaml` is the place put any variables that should not be hardcoded in python. Then you can use these variables in your component to authenticate against Cloud services.
 
+<p class='note warning'>
+  By default, Takeoff assumes the configuration is available in the `.takeoff` directory. You can configure this with the optional CLI parameter: `--takeoff_dir my_path`. For example: `takeoff --takeoff_dir my_path` will read both 
+  of Takeoff's yaml files from the `my_path` directory
+</p>
+
 The basic setup contains:
 
 ```yaml
@@ -32,6 +37,9 @@ azure:
 | `ci_environment_keys_acp` __[optional]__ | Environment variables for your acceptance environment | [Jump to values](takeoff-config#ci_environment_keys)
 | `ci_environment_keys_prd` __[optional]__ | Environment variables for your production environment | [Jump to values](takeoff-config#ci_environment_keys)
 | `azure` __[optional]__ | Microsoft Azure specific values | [Jump to values](takeoff-config#azure)
+
+
+
 
 ## environment_keys
 

--- a/scripts/takeoff
+++ b/scripts/takeoff
@@ -1,4 +1,13 @@
 #!/usr/bin/python3 -u
-from takeoff.deploy import main
+import click
+from takeoff.deploy import main as takeoff_main
 
-main()
+
+@click.command()
+@click.option('--takeoff_dir', default=".takeoff", help='')
+def main(takeoff_dir):
+    takeoff_main(takeoff_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/takeoff/deploy.py
+++ b/takeoff/deploy.py
@@ -54,7 +54,7 @@ def add_takeoff_plugin_paths(dirs: List[str]):
     sys.path.extend(dirs)
 
 
-def main():
+def main(takeoff_dir: str = ".takeoff"):
     logger.info(  # noqa: W605
         """
   ______      __              ________
@@ -65,8 +65,9 @@ def main():
 
     """
     )
-    deployment = load_yaml(get_full_yaml_filename("deployment"))
-    config = load_yaml(get_full_yaml_filename("config"))
+    logger.info(f"Loading Takeoff configuration from {takeoff_dir}")
+    deployment = load_yaml(get_full_yaml_filename("deployment", takeoff_dir))
+    config = load_yaml(get_full_yaml_filename("config", takeoff_dir))
     if "plugins" in config:
         paths = config["plugins"]
         logger.info(f"Adding plugins from {paths} and current working directory")

--- a/takeoff/util.py
+++ b/takeoff/util.py
@@ -161,10 +161,10 @@ def inverse_dictionary(d: dict):
     return {v: k for k, v in d.items()}
 
 
-def get_full_yaml_filename(filename: str) -> str:
+def get_full_yaml_filename(filename: str, takeoff_dir: str = ".takeoff") -> str:
     extensions = (".yaml", ".yml")
     for ext in extensions:
-        concat_filename = os.path.join(".takeoff", f"{filename}{ext}")
+        concat_filename = os.path.join(takeoff_dir, f"{filename}{ext}")
         if os.path.isfile(concat_filename):
             return concat_filename
         else:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -28,7 +28,7 @@ env = ApplicationVersion("DEV", "abc123githash", 'some-branch')
 conf_ext = {"environment_keys": {"application_name": "CI_PROJECT_NAME"}}
 
 
-def filename(s):
+def filename(s, _):
     return f".takeoff/{s}.yml"
 
 


### PR DESCRIPTION
## Summary:
This CLI parameter allows you to define a different path name than `.takeoff`. The default is still `.takeoff`, and the filenames are still expected to be `.takeoff/config.yml` and `.takeoff/deployment.yml`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
