### PR TITLE
Add run immediately option databricks

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 name: Schiphol Takeoff
 
 project:
-  version: 2.0.2
+  version: 2.0.5
   github: https://github.com/schipholgroup/takeoff
 
 markdown: kramdown

--- a/docs/_deployment-steps/deploy_to_databricks.md
+++ b/docs/_deployment-steps/deploy_to_databricks.md
@@ -23,6 +23,7 @@ Add the following task to ``deployment.yaml``:
     config_file: databricks.json.j2
     lang: python
     name: foo
+    run_stream_job_immediately: False
     arguments:
     - eventhubs.consumer_group: "my-consumer-group"
 ```
@@ -35,8 +36,9 @@ This should be after the [upload_to_blob](upload-to-blob) task if used together
 | `jobs` | A list of job configurations | Must have at least one job |
 | `jobs[].main_name` | When `lang` is `python` must be the path to the python main file. When `lang` is `scala` it must be a class name | For `python`: `main/main.py`, for `scala`: `com.databricks.ComputeModels`.
 | `jobs[].config_file` | The path to a `json` [jinja templated](http://jinja.pocoo.org/) [Databricks job config](https://docs.databricks.com/api/latest/jobs.html#create) | defaults to `databricks.json.j2`
-| `jobs[].name` (optional) | A postfix to identify your job on Databricks | A postfix of `foo` will name your job `application-name_foo-version`. Defaults to no postfix. This will name all the jobs (if you have multiple) the same.
 | `jobs[].lang` (optional) | The language identifier of your project | One of `python`, `scala`, defaults to `python`
+| `jobs[].name` (optional) | A postfix to identify your job on Databricks | A postfix of `foo` will name your job `application-name_foo-version`. Defaults to no postfix. This will name all the jobs (if you have multiple) the same.
+| `jobs[].run_stream_job_immediately` (optional) | Whether or not to run a stream job immediately | `True` or `False`. Defaults to `True`.
 | `jobs[].arguments` (optional) | Key value pairs to be passed into your project | defaults to no arguments
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup_dependencies = [
     "databricks-cli==0.9.0",
     "docker==4.0.2",
     "flake8==3.7.2",
-    "gitpython==3.0.2",
+    "gitpython==3.1.1",
     "jinja2==2.10.1",
     "kubernetes==10.0.1",
     "py4j==0.10.7",

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -29,7 +29,7 @@ SCHEMA = TAKEOFF_BASE_SCHEMA.extend(
                     vol.Optional("config_file", default="databricks.json.j2"): str,
                     vol.Optional("name", default=""): str,
                     vol.Optional("lang", default="python"): vol.All(str, vol.In(["python", "scala"])),
-                    vol.Optional("run_immediately", default=True): bool,
+                    vol.Optional("run_stream_job_immediately", default=True): bool,
                     vol.Optional("arguments", default=[{}]): [{}],
                     vol.Optional("schedule"): {
                         vol.Required("quartz_cron_expression"): str,
@@ -88,14 +88,14 @@ class DeployToDatabricks(Step):
             job_name = f"{app_name}-{self.env.artifact_tag}"
             job_config = self.create_config(job_name, job)
             is_streaming = self._job_is_streaming(job_config)
-            run_immediately = job["run_immediately"]
+            run_stream_job_immediately = job["run_stream_job_immediately"]
 
             logger.info("Removing old job")
             self.remove_job(self.env.artifact_tag, job_config=job, is_streaming=is_streaming)
 
             logger.info("Submitting new job with configuration:")
             logger.info(pprint.pformat(job_config))
-            self._submit_job(job_config, is_streaming, run_immediately)
+            self._submit_job(job_config, is_streaming, run_stream_job_immediately)
 
     def create_config(self, job_name: str, job_config: dict):
         common_arguments = dict(
@@ -192,11 +192,11 @@ class DeployToDatabricks(Step):
             logger.info(f"Canceling active runs {active_run_ids}")
             [self.runs_api.cancel_run(_) for _ in active_run_ids]
 
-    def _submit_job(self, job_config: dict, is_streaming: bool, run_immediately: bool):
+    def _submit_job(self, job_config: dict, is_streaming: bool, run_stream_job_immediately: bool):
         job_resp = self.jobs_api.create_job(job_config)
         logger.info(f"Created Job with ID {job_resp['job_id']}")
 
-        if is_streaming or run_immediately:
+        if is_streaming and run_stream_job_immediately:
             resp = self.jobs_api.run_now(
                 job_id=job_resp["job_id"],
                 jar_params=None,

--- a/takeoff/util.py
+++ b/takeoff/util.py
@@ -205,7 +205,7 @@ def run_shell_command(command: List[str]) -> Tuple[int, List]:
     process = subprocess.Popen(command, stdout=subprocess.PIPE, cwd="./", universal_newlines=True)
     output_lines = []
     while True:
-        output = process.stdout.readline()
+        output = process.stdout.readline()  # type: ignore
         if output == "" and process.poll() is not None:
             break
         if output:

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -599,12 +599,14 @@ class TestDeployToDatabricks(object):
         victim.runs_api.cancel_run.assert_has_calls(calls)
 
     def test_submit_job_batch(self, victim):
-        victim._submit_job({}, False)
+        victim._submit_job({}, False, True)
 
         victim.jobs_api.create_job.assert_called_with({})
 
+        victim.jobs_api.run_now.assert_not_called()
+
     def test_submit_job_streaming(self, victim):
-        victim._submit_job({}, True)
+        victim._submit_job({}, True, True)
 
         victim.jobs_api.create_job.assert_called_with({})
 
@@ -615,3 +617,10 @@ class TestDeployToDatabricks(object):
             python_params=None,
             spark_submit_params=None,
         )
+
+    def test_submit_job_streaming_without_immediate_run(self, victim):
+        victim._submit_job({}, True, False)
+
+        victim.jobs_api.create_job.assert_called_with({})
+
+        victim.jobs_api.run_now.assert_not_called()

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -598,15 +598,15 @@ class TestDeployToDatabricks(object):
         calls = [mock.call("run1"), mock.call("run2")]
         victim.runs_api.cancel_run.assert_has_calls(calls)
 
-    def test_submit_job_batch(self, victim):
-        victim._submit_job({}, False, True)
+    def test_deploy_job_batch(self, victim):
+        victim.deploy_job({}, False, True)
 
         victim.jobs_api.create_job.assert_called_with({})
 
         victim.jobs_api.run_now.assert_not_called()
 
     def test_submit_job_streaming(self, victim):
-        victim._submit_job({}, True, True)
+        victim.deploy_job({}, True, True)
 
         victim.jobs_api.create_job.assert_called_with({})
 
@@ -619,7 +619,7 @@ class TestDeployToDatabricks(object):
         )
 
     def test_submit_job_streaming_without_immediate_run(self, victim):
-        victim._submit_job({}, True, False)
+        victim.deploy_job({}, True, False)
 
         victim.jobs_api.create_job.assert_called_with({})
 


### PR DESCRIPTION
## Summary:

As mentioned in #55 there are cases in which you submit a streaming job and do not want to run it immediately. This PR adds functionality to `deploy_to_databricks` to support this. It adds an optional parameter to the `deploy_to_databricks` step, which gives the user control of whether or not to run the streaming job immediately. The default value is `True`.

It also bumps the version of `gitpython` as a minor side-effect, as the previous versions had issues (documented here: https://github.com/gitpython-developers/GitPython/issues/983) 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
