### PR TITLE
Remove unnecessary mock package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,8 @@ setup_dependencies = [
 ]
 
 test_dependencies = [
-    "mock==2.0.0",
-    "pytest==3.8.2",
-    "pytest-cov==2.6.0",
+    "pytest==5.4.1",
+    "pytest-cov==2.8.1",
     "black==19.3b0"
 ]
 

--- a/takeoff/util.py
+++ b/takeoff/util.py
@@ -205,7 +205,7 @@ def run_shell_command(command: List[str]) -> Tuple[int, List]:
     process = subprocess.Popen(command, stdout=subprocess.PIPE, cwd="./", universal_newlines=True)
     output_lines = []
     while True:
-        output = process.stdout.readline()
+        output = process.stdout.readline()  # type: ignore
         if output == "" and process.poll() is not None:
             break
         if output:

--- a/tests/azure/credentials/base_keyvault_test.py
+++ b/tests/azure/credentials/base_keyvault_test.py
@@ -1,8 +1,7 @@
 import abc
 import unittest
 from dataclasses import dataclass
-
-import mock
+from unittest import mock
 
 
 @dataclass

--- a/tests/azure/credentials/test_keyvault.py
+++ b/tests/azure/credentials/test_keyvault.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from takeoff.application_version import ApplicationVersion
 from takeoff.azure.credentials.keyvault import KeyVaultClient as victim

--- a/tests/azure/credentials/test_service_principal.py
+++ b/tests/azure/credentials/test_service_principal.py
@@ -1,6 +1,5 @@
 import os
-
-import mock
+from unittest import mock
 
 from takeoff.azure.credentials.service_principal import ServicePrincipalCredentials as victim
 from tests.credentials.base_environment_keys_test import EnvironmentKeyBaseTest, OS_KEYS

--- a/tests/azure/test_build_docker_image.py
+++ b/tests/azure/test_build_docker_image.py
@@ -1,7 +1,8 @@
 import base64
 import os
 
-import mock
+from unittest import mock
+
 import pytest
 
 from takeoff.application_version import ApplicationVersion

--- a/tests/azure/test_configure_eventhub.py
+++ b/tests/azure/test_configure_eventhub.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
+from unittest import mock
 
-import mock
 import pytest
 import voluptuous as vol
 from azure.mgmt.relay.models import AccessRights

--- a/tests/azure/test_create_application_insights.py
+++ b/tests/azure/test_create_application_insights.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
+from unittest import mock
 
-import mock
 import pytest
 from voluptuous import MultipleInvalid
 

--- a/tests/azure/test_create_databricks_secrets.py
+++ b/tests/azure/test_create_databricks_secrets.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
+from unittest import mock
 
-import mock
 import pytest
 
 from takeoff.application_version import ApplicationVersion

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -1,9 +1,9 @@
 import os
 from dataclasses import dataclass
+from unittest import mock
 
 import pytest
 import voluptuous as vol
-from mock import mock
 
 from takeoff.application_version import ApplicationVersion
 from takeoff.azure.deploy_to_databricks import JobConfig, SCHEMA, DeployToDatabricks

--- a/tests/azure/test_publish_artifact.py
+++ b/tests/azure/test_publish_artifact.py
@@ -1,9 +1,9 @@
 import glob
 import os
 import unittest
+from unittest import mock
 
 import azure
-import mock
 import pytest
 import voluptuous as vol
 

--- a/tests/azure/test_util.py
+++ b/tests/azure/test_util.py
@@ -1,7 +1,6 @@
 import os
 import sys
-
-import mock
+from unittest import mock
 
 from takeoff.application_version import ApplicationVersion
 from takeoff.azure import util as victim

--- a/tests/credentials/base_environment_keys_test.py
+++ b/tests/credentials/base_environment_keys_test.py
@@ -2,7 +2,7 @@ import abc
 import os
 import unittest
 
-import mock
+from unittest import mock
 
 OS_KEYS = {'AZ_SP_CLIENT_ID_ENV': 'd0aaa0de-c1ef-456f-a025-c5d6341193bb',
            'AZ_SP_CLIENT_SECRET_ENV': '3ceb401f-6462-48da-b42f-b1d1745c2590',

--- a/tests/credentials/test_application_name.py
+++ b/tests/credentials/test_application_name.py
@@ -1,6 +1,6 @@
 import os
+from unittest import mock
 
-import mock
 
 from takeoff.credentials.application_name import ApplicationName as victim
 from tests.credentials.base_environment_keys_test import EnvironmentKeyBaseTest, CONFIG, OS_KEYS

--- a/tests/credentials/test_branch_name.py
+++ b/tests/credentials/test_branch_name.py
@@ -1,6 +1,5 @@
 import os
-
-import mock
+from unittest import mock
 
 from takeoff.credentials.branch_name import BranchName as victim
 from tests.credentials.base_environment_keys_test import EnvironmentKeyBaseTest, CONFIG, OS_KEYS

--- a/tests/credentials/test_container_registry.py
+++ b/tests/credentials/test_container_registry.py
@@ -1,6 +1,6 @@
 import os
 
-import mock
+from unittest import mock
 
 from takeoff.application_version import ApplicationVersion
 from takeoff.credentials.container_registry import DockerRegistry as victim, DockerCredentials

--- a/tests/test_build_artifact.py
+++ b/tests/test_build_artifact.py
@@ -1,7 +1,8 @@
 import os
 import unittest
 
-import mock
+from unittest import mock
+
 import pytest
 
 from takeoff.application_version import ApplicationVersion


### PR DESCRIPTION
## Summary:

The mock package was being explicitly installed. This package is only
intended as a backport of the now integrated-into-unittest mocking
functionality (documented here: https://docs.python.org/3/library/unittest.mock.html)
for versions of python before 3.3. Takeoff does not support those
versions anyway, so the backport is unnecessary

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
