### PR TITLE
fixed two minor typos in plugin documentation

### DIFF
--- a/docs/takeoff_plugins.md
+++ b/docs/takeoff_plugins.md
@@ -61,9 +61,9 @@ Other functions you can overwrite are the ones that use naming conventions. Thes
     ```python
     def get_cosmos_name(config: dict, env: ApplicationVersion) -> str
     ```
-- EvenHub namespace 
+- EventHub namespace 
     ```python
-    def get_eventhub_name(config: dict, env: ApplicationVersion) -> sts
+    def get_eventhub_name(config: dict, env: ApplicationVersion) -> str
     ```
 - EventHub entity (equivalent of a kafka topic)
     ```python


### PR DESCRIPTION
## Summary:

Two small typos in the plugin documentation.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR
