### PR TITLE
Typo in takeoff_config.md

### DIFF
--- a/docs/takeoff_config.md
+++ b/docs/takeoff_config.md
@@ -61,7 +61,7 @@ environment_keys:
 
 The optional fields are
 ```yaml
-environment_keys:
+common:
   databricks_fs_libraries_mount_path: "dbfs:/mnt/libraries"
 ```
 


### PR DESCRIPTION
## Summary:
The example for the key "common" was wrong, it said environment_keys.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR