### PR TITLE
Support unscheduled batch

### DIFF
--- a/docs/_deployment-steps/deploy_to_databricks.md
+++ b/docs/_deployment-steps/deploy_to_databricks.md
@@ -24,6 +24,7 @@ Add the following task to ``deployment.yaml``:
     lang: python
     name: foo
     run_stream_job_immediately: False
+    is_unscheduled_batch: False
     arguments:
     - eventhubs.consumer_group: "my-consumer-group"
 ```
@@ -39,10 +40,11 @@ This should be after the [upload_to_blob](upload-to-blob) task if used together
 | `jobs[].lang` (optional) | The language identifier of your project | One of `python`, `scala`, defaults to `python`
 | `jobs[].name` (optional) | A postfix to identify your job on Databricks | A postfix of `foo` will name your job `application-name_foo-version`. Defaults to no postfix. This will name all the jobs (if you have multiple) the same.
 | `jobs[].run_stream_job_immediately` (optional) | Whether or not to run a stream job immediately | `True` or `False`. Defaults to `True`.
+| `jobs[].is_unscheduled_batch` (optional) | Designate job as an unscheduled batch | `True` or `False`. Defaults to `False`.
 | `jobs[].arguments` (optional) | Key value pairs to be passed into your project | defaults to no arguments
 
 
-The `json` file can use any of [supported keys](https://docs.databricks.com/api/latest/jobs.html#request-structure). During deployment the existence of the key `schedule` in the `json` file will determine if the job is streaming or batch. When `schedule` is present it is considered a batch job, otherwise a streaming job. A streaming job will be kicked off immediately upon deployment.
+The `json` file can use any of [supported keys](https://docs.databricks.com/api/latest/jobs.html#request-structure). During deployment the existence of the key `schedule` in the `json` file will determine if the job is streaming or batch. When `schedule` is present or `is_unscheduled_batch` has been set to `True`, it is considered a batch job, otherwise a streaming job. A streaming job will be kicked off immediately upon deployment.
 
 An example of `databricks.json.pyspark.j2` 
 

--- a/docs/_deployment-steps/deploy_to_databricks.md
+++ b/docs/_deployment-steps/deploy_to_databricks.md
@@ -24,7 +24,7 @@ Add the following task to ``deployment.yaml``:
     lang: python
     name: foo
     run_stream_job_immediately: False
-    is_unscheduled_batch: False
+    is_batch: False
     arguments:
     - eventhubs.consumer_group: "my-consumer-group"
 ```
@@ -40,11 +40,11 @@ This should be after the [upload_to_blob](upload-to-blob) task if used together
 | `jobs[].lang` (optional) | The language identifier of your project | One of `python`, `scala`, defaults to `python`
 | `jobs[].name` (optional) | A postfix to identify your job on Databricks | A postfix of `foo` will name your job `application-name_foo-version`. Defaults to no postfix. This will name all the jobs (if you have multiple) the same.
 | `jobs[].run_stream_job_immediately` (optional) | Whether or not to run a stream job immediately | `True` or `False`. Defaults to `True`.
-| `jobs[].is_unscheduled_batch` (optional) | Designate job as an unscheduled batch | `True` or `False`. Defaults to `False`.
+| `jobs[].is_batch` (optional) | Designate job as an unscheduled batch | `True` or `False`. Defaults to `False`.
 | `jobs[].arguments` (optional) | Key value pairs to be passed into your project | defaults to no arguments
 
 
-The `json` file can use any of [supported keys](https://docs.databricks.com/api/latest/jobs.html#request-structure). During deployment the existence of the key `schedule` in the `json` file will determine if the job is streaming or batch. When `schedule` is present or `is_unscheduled_batch` has been set to `True`, it is considered a batch job, otherwise a streaming job. A streaming job will be kicked off immediately upon deployment.
+The `json` file can use any of [supported keys](https://docs.databricks.com/api/latest/jobs.html#request-structure). During deployment the existence of the key `schedule` in the `json` file will determine if the job is streaming or batch. When `schedule` is present or `is_batch` has been set to `True`, it is considered a batch job, otherwise a streaming job. A streaming job will be kicked off immediately upon deployment.
 
 An example of `databricks.json.pyspark.j2` 
 

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -30,7 +30,7 @@ SCHEMA = TAKEOFF_BASE_SCHEMA.extend(
                     vol.Optional("name", default=""): str,
                     vol.Optional("lang", default="python"): vol.All(str, vol.In(["python", "scala"])),
                     vol.Optional("run_stream_job_immediately", default=True): bool,
-                    vol.Optional("is_unscheduled_batch", default=False): bool,
+                    vol.Optional("is_batch", default=False): bool,
                     vol.Optional("arguments", default=[{}]): [{}],
                     vol.Optional("schedule"): {
                         vol.Required("quartz_cron_expression"): str,
@@ -88,7 +88,7 @@ class DeployToDatabricks(Step):
             app_name = self._construct_name(job["name"])
             job_name = f"{app_name}-{self.env.artifact_tag}"
             job_config = self.create_config(job_name, job)
-            is_streaming = self._job_is_unscheduled(job_config) and not job["is_unscheduled_batch"]
+            is_streaming = self._job_is_unscheduled(job_config) and not job["is_batch"]
             run_stream_job_immediately = job["run_stream_job_immediately"]
 
             logger.info("Removing old job")

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -66,16 +66,6 @@ class DeployToDatabricks(Step):
     def run(self):
         self.deploy_to_databricks()
 
-    @staticmethod
-    def _job_is_unscheduled(job_config: dict):
-        """
-        If there is no schedule, the job would not run periodically, therefore we assume that is a
-        streaming job
-        :param job_config: the configuration of the Databricks job
-        :return: (bool) if it is a streaming job
-        """
-        return "schedule" not in job_config.keys()
-
     def deploy_to_databricks(self):
         """
         The application parameters (cosmos and eventhub) will be removed from this file as they
@@ -88,7 +78,7 @@ class DeployToDatabricks(Step):
             app_name = self._construct_name(job["name"])
             job_name = f"{app_name}-{self.env.artifact_tag}"
             job_config = self.create_config(job_name, job)
-            is_streaming = self._job_is_unscheduled(job_config) and not job["is_batch"]
+            is_streaming = not job["is_batch"] and "schedule" not in job_config.keys()
             run_stream_job_immediately = job["run_stream_job_immediately"]
 
             logger.info("Removing old job")

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -69,10 +69,9 @@ class DeployToDatabricks(Step):
     @staticmethod
     def _job_is_unscheduled(job_config: dict):
         """
-        If there is no schedule, the job would not run periodically, therefore we assume that is a
-        streaming job
+        Checks if a job is scheduled
         :param job_config: the configuration of the Databricks job
-        :return: (bool) if it is a streaming job
+        :return: (bool) if it is scheduled
         """
         return "schedule" not in job_config.keys()
 
@@ -81,8 +80,7 @@ class DeployToDatabricks(Step):
         The application parameters (cosmos and eventhub) will be removed from this file as they
         will be set as databricks secrets eventually
         If the job is a streaming job this will directly start the new job_run given the new
-        configuration. If the job is batch this will not start it manually, assuming the schedule
-        has been set correctly.
+        configuration. If the job is batch this will not start it manually.
         """
         for job in self.config["jobs"]:
             app_name = self._construct_name(job["name"])

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -66,6 +66,16 @@ class DeployToDatabricks(Step):
     def run(self):
         self.deploy_to_databricks()
 
+    @staticmethod
+    def _job_is_unscheduled(job_config: dict):
+        """
+        If there is no schedule, the job would not run periodically, therefore we assume that is a
+        streaming job
+        :param job_config: the configuration of the Databricks job
+        :return: (bool) if it is a streaming job
+        """
+        return "schedule" not in job_config.keys()
+
     def deploy_to_databricks(self):
         """
         The application parameters (cosmos and eventhub) will be removed from this file as they
@@ -78,7 +88,7 @@ class DeployToDatabricks(Step):
             app_name = self._construct_name(job["name"])
             job_name = f"{app_name}-{self.env.artifact_tag}"
             job_config = self.create_config(job_name, job)
-            is_streaming = not job["is_batch"] and "schedule" not in job_config.keys()
+            is_streaming = self._job_is_unscheduled(job_config) and not job["is_batch"]
             run_stream_job_immediately = job["run_stream_job_immediately"]
 
             logger.info("Removing old job")

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -100,13 +100,6 @@ class TestDeployToDatabricks(object):
         assert victim._construct_name("") == "my_app"
         assert victim._construct_name("foo") == "my_app-foo"
 
-    def test_job_is_unscheduled(self, victim):
-        job_config = victim._construct_job_config(config_file=streaming_job_config)
-        assert victim._job_is_unscheduled(job_config) is True
-
-        job_config = victim._construct_job_config(config_file=batch_job_config)
-        assert victim._job_is_unscheduled(job_config) is False
-
     def test_construct_job_config(self, victim):
         job_config = victim._construct_job_config(
             config_file=streaming_job_config,

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -200,11 +200,11 @@ class TestDeployToDatabricks(object):
             **takeoff_config(),
             **{
                 "task": "deploy_to_databricks",
-                "jobs": [{"main_name": "foo", "name": "some-name", 'is_unscheduled_batch': True}],
+                "jobs": [{"main_name": "foo", "name": "some-name", 'is_batch': True}],
             },
         }
         res = SCHEMA(conf)["jobs"][0]
-        assert res["is_unscheduled_batch"] is True
+        assert res["is_batch"] is True
 
         conf = {
             **takeoff_config(),
@@ -214,7 +214,7 @@ class TestDeployToDatabricks(object):
             },
         }
         res = SCHEMA(conf)["jobs"][0]
-        assert res["is_unscheduled_batch"] is False
+        assert res["is_batch"] is False
 
     def test_yaml_to_databricks_json(self, victim):
         conf = {

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -100,12 +100,12 @@ class TestDeployToDatabricks(object):
         assert victim._construct_name("") == "my_app"
         assert victim._construct_name("foo") == "my_app-foo"
 
-    def test_is_streaming_job(self, victim):
+    def test_job_is_unscheduled(self, victim):
         job_config = victim._construct_job_config(config_file=streaming_job_config)
-        assert victim._job_is_streaming(job_config) is True
+        assert victim._job_is_unscheduled(job_config) is True
 
         job_config = victim._construct_job_config(config_file=batch_job_config)
-        assert victim._job_is_streaming(job_config) is False
+        assert victim._job_is_unscheduled(job_config) is False
 
     def test_construct_job_config(self, victim):
         job_config = victim._construct_job_config(

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -100,6 +100,13 @@ class TestDeployToDatabricks(object):
         assert victim._construct_name("") == "my_app"
         assert victim._construct_name("foo") == "my_app-foo"
 
+    def test_job_is_unscheduled(self, victim):
+        job_config = victim._construct_job_config(config_file=streaming_job_config)
+        assert victim._job_is_unscheduled(job_config) is True
+
+        job_config = victim._construct_job_config(config_file=batch_job_config)
+        assert victim._job_is_unscheduled(job_config) is False
+
     def test_construct_job_config(self, victim):
         job_config = victim._construct_job_config(
             config_file=streaming_job_config,

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -196,6 +196,26 @@ class TestDeployToDatabricks(object):
         res = SCHEMA(conf)["jobs"][0]
         assert res["arguments"] == [{"key": "val"}, {"key2": "val2"}]
 
+        conf = {
+            **takeoff_config(),
+            **{
+                "task": "deploy_to_databricks",
+                "jobs": [{"main_name": "foo", "name": "some-name", 'is_unscheduled_batch': True}],
+            },
+        }
+        res = SCHEMA(conf)["jobs"][0]
+        assert res["is_unscheduled_batch"] is True
+
+        conf = {
+            **takeoff_config(),
+            **{
+                "task": "deploy_to_databricks",
+                "jobs": [{"main_name": "foo", "name": "some-name"}],
+            },
+        }
+        res = SCHEMA(conf)["jobs"][0]
+        assert res["is_unscheduled_batch"] is False
+
     def test_yaml_to_databricks_json(self, victim):
         conf = {
             "main_name": "foo.class",


### PR DESCRIPTION
## Summary:

Unscheduled Databricks batch jobs were not supported. I intend to schedule my jobs elsewhere, similar to the story of #60. Jobs were labeled as batch or streaming based on the presence of a schedule. I added the configuration variable `is_unscheduled_batch` to override this behavior. If set to `True`, a job without a schedule will be labeled as batch. Defaults to `False` so it shouldn't break anything.

One thing I'm not sure about: what should happen if a job has a schedule and `is_unscheduled_batch` is `True`? Right now, nothing changes because it only overrides the choice for streaming. In that light, `is_batch` might be a more appropriate name, consistent with its behavior. Can change it to this if that's better. 

Sidenote: black formatted a method i haven't touched, so I didn't include it in this PR

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
