### PR TITLE
Add build_env to parameters used for rendering kubernetes template

### DIFF
--- a/docs/_deployment-steps/deploy_to_kubernetes.md
+++ b/docs/_deployment-steps/deploy_to_kubernetes.md
@@ -127,6 +127,17 @@ azure:
       registry: "registry-server"
 ```
 
+## Default fields available for rendering
+The following fields are available while rendering your Kubernetes yaml template:
+{:.table}
+| field | description 
+| ----- | ----------- 
+| `docker_tag` | the tag assigned to the docker image (based on environment configuration)|
+| `application_name` | the application name (used throughout takeoff) |
+| `env` | the deployment environment (used throughout takeoff) |
+| `build_env` | the contents of the build-runner's environment variables |
+
+
 ## Examples
 Minimum Takeoff deployment configuration example to deploy Kubernetes resources. This will not create image pull secrets:
 ```yaml

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -166,6 +166,7 @@ class DeployToKubernetes(BaseKubernetes):
                 "docker_tag": self.env.artifact_tag,
                 "application_name": application_name,
                 "env": self.env.environment,
+                "build_env": {**os.environ},
                 **secrets,
                 **custom_values,
             },

--- a/takeoff/util.py
+++ b/takeoff/util.py
@@ -5,7 +5,7 @@ import os
 import pkgutil
 import subprocess
 from dataclasses import dataclass
-from typing import Callable, List, Pattern, Union, Tuple
+from typing import Callable, List, Pattern, Union, Tuple, Optional, Any
 
 import jinja2
 from git import Repo
@@ -194,7 +194,7 @@ def get_jar_name(build_definition_name: str, artifact_tag: str, file_ext: str) -
     return f"{build_definition_name}/{build_definition_name}-{artifact_tag}{file_ext}"
 
 
-def run_shell_command(command: List[str]) -> Tuple[int, List]:
+def run_shell_command(command: List[str]) -> Tuple[Optional[int], List[Union[str, Any]]]:
     """Runs a shell command using `subprocess.Popen`
 
     In addition to running any bash command, the output of process is streamed directly to the stdout.


### PR DESCRIPTION
## Summary:

This PR adds a parameter to the jinja template rendering of the Kubernetes config in the deploy_to_kubernetes step. Having the build_env available can be useful in a CI pipeline as it enabled you to pass in dynamic variables from a previous CI step. For example, if in CI step A you determine (via custom scripting) what version of an artifact should be deployed, it would be nice if this version number could be dynamically injected into the Kubernetes configuration in the deploy step. This enables that using environment variables.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
