### PR TITLE
Allow optional postfix to a version

### DIFF
--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -176,7 +176,7 @@ class DeployToDatabricks(Step):
     @staticmethod
     def _application_job_id(application_name: str, branch: str, jobs: List[JobConfig]) -> List[int]:
         snapshot = "SNAPSHOT"
-        tag = "\d+\.\d+\.\d+"
+        tag = "\d+\.\d+\.\d+.*"
         pattern = re.compile(rf"^({application_name})-({snapshot}|{tag}|{branch})$")
 
         return [_.job_id for _ in jobs if has_prefix_match(_.name, application_name, pattern)]

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -98,7 +98,7 @@ class TestDeployToDatabricks(object):
         assert victim._application_job_id("tim-postfix", "SNAPSHOT", jobs) == [6, 7]
 
     def test_find_application_job_id_if_version_postfix(self, victim):
-        assert victim._application_job_id("michel", "1.2.3--my-verson-postfix", jobs) == [8]
+        assert victim._application_job_id("michel", "1.2.3--my-version-postfix", jobs) == [8]
 
     def test_construct_name(self, victim):
         assert victim._construct_name("") == "my_app"

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -17,6 +17,7 @@ jobs = [
     JobConfig("daniel-branch-name", 5),
     JobConfig("tim-postfix-SNAPSHOT", 6),
     JobConfig("tim-postfix-SNAPSHOT", 7),
+    JobConfig("michel-1.2.3--my-version-postfix", 8),
 ]
 
 streaming_job_config = "tests/azure/files/test_job_config.json.j2"
@@ -95,6 +96,9 @@ class TestDeployToDatabricks(object):
 
     def test_find_application_job_id_if_postfix(self, victim):
         assert victim._application_job_id("tim-postfix", "SNAPSHOT", jobs) == [6, 7]
+
+    def test_find_application_job_id_if_version_postfix(self, victim):
+        assert victim._application_job_id("michel", "1.2.3--my-verson-postfix", jobs) == [8]
 
     def test_construct_name(self, victim):
         assert victim._construct_name("") == "my_app"


### PR DESCRIPTION
## Summary:

TakeOff is restricting versions to format d+.d+.d+ , for example 1.2.3. In our project we also use this format. We are now implementing jobs that we distinct using a version-postfix. For example 1.2.3--my-postfix. The Databricks deploy step however does not delete these jobs. This is due to a fixed format in the application_id logic. The change will allow for an optional postfix after the original version.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.
  - [X] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated
