### PR TITLE
Add option to wait for k8s rollout to complete

### DIFF
--- a/docs/_deployment-steps/deploy_to_kubernetes.md
+++ b/docs/_deployment-steps/deploy_to_kubernetes.md
@@ -160,8 +160,8 @@ steps:
   image_pull_secret: 
     create: True
   restart_unchanged_resources: true
-  wait_for:
-    resource_name: "resource_type/my_resource"
+  wait_for_rollout:
+    resource_name: "deployment/my_app"
     resource_namespace: "my_namespace"
   custom_values:
     dev:
@@ -173,7 +173,7 @@ steps:
 ```
 
 #### Waiting for successful rollout
-In the extended example above, you can see the `wait_for` parameter. This tells Takeoff that it should wait until the specified resource is rolled out successfully. If it is not
+In the extended example above, you can see the `wait_for_rollout` parameter. This tells Takeoff that it should wait until the specified resource is rolled out successfully. If it is not
 rolled out successfully, or is not rolled out successfully quickly enough (e.g. within the default Kubernetes timeout), the task will fail. The failure of this task will trigger 
 Kubernetes to rollback the change and revert to a previous revision that did work.
 
@@ -181,7 +181,7 @@ There are few things to note regarding this option:
 1. It may result in unexpected behaviour if there are several CI jobs running simultaneously that apply changes to the specified Kubernetes resource. It is possible that the wrong
 version is awaited. This is unlikely, but not impossible.
 2. Note that the resource_name __must__ be prefixed with the resource_type. If this is not the case, a schema validation error will be thrown. Also note that not all resources are
-"awaitable". For a full list of resources that can be awaited, we refer you to the Kubernetes documentation.
+"awaitable". For a full list of resources that can be awaited, we refer you to the [Kubernetes documentation](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout).
 
 ### Takeoff Context
 Eventhub producer policy secrets and consumer group secrets from [`configure_eventhub`](deployment-step/configure-eventhub) are available during this task. This makes it possible for the configuration below to inject the secrets into `my_kubernetes_config.yml.j2`:

--- a/docs/_deployment-steps/deploy_to_kubernetes.md
+++ b/docs/_deployment-steps/deploy_to_kubernetes.md
@@ -160,6 +160,9 @@ steps:
   image_pull_secret: 
     create: True
   restart_unchanged_resources: true
+  wait_for:
+    resource_name: "resource_type/my_resource"
+    resource_namespace: "my_namespace"
   custom_values:
     dev:
       url: 'dev-url-here-being-buggy'
@@ -168,6 +171,17 @@ steps:
     prd:
       url: 'prd-url-here-being-glorious'
 ```
+
+#### Waiting for successful rollout
+In the extended example above, you can see the `wait_for` parameter. This tells Takeoff that it should wait until the specified resource is rolled out successfully. If it is not
+rolled out successfully, or is not rolled out successfully quickly enough (e.g. within the default Kubernetes timeout), the task will fail. The failure of this task will trigger 
+Kubernetes to rollback the change and revert to a previous revision that did work.
+
+There are few things to note regarding this option:
+1. It may result in unexpected behaviour if there are several CI jobs running simultaneously that apply changes to the specified Kubernetes resource. It is possible that the wrong
+version is awaited. This is unlikely, but not impossible.
+2. Note that the resource_name __must__ be prefixed with the resource_type. If this is not the case, a schema validation error will be thrown. Also note that not all resources are
+"awaitable". For a full list of resources that can be awaited, we refer you to the Kubernetes documentation.
 
 ### Takeoff Context
 Eventhub producer policy secrets and consumer group secrets from [`configure_eventhub`](deployment-step/configure-eventhub) are available during this task. This makes it possible for the configuration below to inject the secrets into `my_kubernetes_config.yml.j2`:

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -100,7 +100,7 @@ DEPLOY_SCHEMA = TAKEOFF_BASE_SCHEMA.extend(
         },
         vol.Optional("custom_values", default={}): {},
         vol.Optional("restart_unchanged_resources", default=False): bool,
-        vol.Optional("wait_for", default={}): {
+        vol.Optional("wait_for_rollout"): {
             vol.Optional("resource_name", default="foo/bar"): vol.All(str, vol.Match("^.*/.*$")),
             vol.Optional("resource_namespace", default=""): str,
         },
@@ -337,9 +337,10 @@ class DeployToKubernetes(BaseKubernetes):
         if self.config["restart_unchanged_resources"]:
             self._restart_unchanged_resources(rendered_kubernetes_config_path)
 
-        if self.config["wait_for"]:
+        if "wait_for_rollout" in self.config.keys():
             self._await_rollout(
-                self.config["wait_for"]["resource_name"], self.config["wait_for"]["resource_namespace"]
+                self.config["wait_for_rollout"]["resource_name"],
+                self.config["wait_for_rollout"]["resource_namespace"],
             )
 
     @property

--- a/takeoff/azure/deploy_to_kubernetes.py
+++ b/takeoff/azure/deploy_to_kubernetes.py
@@ -102,7 +102,7 @@ DEPLOY_SCHEMA = TAKEOFF_BASE_SCHEMA.extend(
         vol.Optional("restart_unchanged_resources", default=False): bool,
         vol.Optional("wait_for", default={}): {
             vol.Optional("resource_name", default="foo/bar"): vol.All(str, vol.Match("^.*/.*$")),
-            vol.Optional("resource_namespace", default=""): str
+            vol.Optional("resource_namespace", default=""): str,
         },
         "azure": {
             vol.Required(
@@ -232,16 +232,17 @@ class DeployToKubernetes(BaseKubernetes):
     def _await_rollout(self, target: str, target_namespace: str):
         """Await the rollout of a specified target to complete
 
-        This function awaits the completion of the rollout of the target in the target_namespace. If it fails, or
-        if it does not complete successfully within the default kubectl timeout, a ChildProcessorError is thrown.
+        This function awaits the completion of the rollout of the target in the target_namespace. If it
+        fails, or if it does not complete successfully within the default kubectl timeout, a
+        ChildProcessorError is thrown.
 
         NOTE: This may be a bit 'racy', in the sense that if multiple CI pipelines are running simultaneously,
         the await may not always be correct (it may await a different revision than the one that this step had
         just deployed).
 
         Args:
-            target: The resource to target. This resource should be named according to the <resource_type>/name
-                    convention.
+            target: The resource to target. This resource should be named according to the
+                    <resource_type>/name convention.
             target_namespace: The namespace of the resource
 
         Raises:
@@ -250,8 +251,10 @@ class DeployToKubernetes(BaseKubernetes):
         cmd = ["kubectl", "rollout", "--namespace", target_namespace, "status", target, "--watch=True"]
         exit_code, _ = run_shell_command(cmd)
         if exit_code != 0:
-            raise ChildProcessError(f"Specified deployment {target} in namespace {target_namespace} "
-                                    "did not successfully rollout.")
+            raise ChildProcessError(
+                f"Specified deployment {target} in namespace {target_namespace} "
+                "did not successfully rollout."
+            )
         logger.info("Rollout successful")
 
     def _apply_kubernetes_config_file(self, file_path: str):
@@ -335,8 +338,9 @@ class DeployToKubernetes(BaseKubernetes):
             self._restart_unchanged_resources(rendered_kubernetes_config_path)
 
         if self.config["wait_for"]:
-            self._await_rollout(self.config["wait_for"]["resource_name"],
-                                self.config["wait_for"]["resource_namespace"])
+            self._await_rollout(
+                self.config["wait_for"]["resource_name"], self.config["wait_for"]["resource_namespace"]
+            )
 
     @property
     def kubernetes_namespace(self):

--- a/tests/azure/test_deploy_kubernetes.py
+++ b/tests/azure/test_deploy_kubernetes.py
@@ -191,7 +191,7 @@ spec:
     @mock.patch("takeoff.step.ApplicationName.get", return_value="my_little_pony")
     @mock.patch("takeoff.azure.deploy_to_kubernetes.KeyVaultClient.vault_and_client", return_value=(None, None))
     def test_validate_await_invalid_resource_name(self, _, __):
-        custom_conf = {'wait_for': {'resource_name': 'invalid_name', 'resource_namespace': 'my_space'}, **BASE_CONF}
+        custom_conf = {'wait_for_rollout': {'resource_name': 'invalid_name', 'resource_namespace': 'my_space'}, **BASE_CONF}
         conf = {**takeoff_config(), **custom_conf}
 
         with pytest.raises(voluptuous.error.MultipleInvalid):


### PR DESCRIPTION
## Summary:

Add the option for Takeoff to wait for completion of
the rollout of a specified kubernetes object. If it fails, or times
out, the entire Takeoff deployment will fail.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
