### PR TITLE
add formatting to eventhub consumer group name

### DIFF
--- a/takeoff/azure/configure_eventhub.py
+++ b/takeoff/azure/configure_eventhub.py
@@ -13,7 +13,12 @@ from takeoff.azure.create_databricks_secrets import CreateDatabricksSecretFromVa
 from takeoff.azure.credentials.active_directory_user import ActiveDirectoryUserCredentials
 from takeoff.azure.credentials.keyvault import KeyVaultClient
 from takeoff.azure.credentials.subscription_id import SubscriptionId
-from takeoff.azure.util import get_resource_group_name, get_eventhub_name, get_eventhub_entity_name
+from takeoff.azure.util import (
+    get_resource_group_name,
+    get_eventhub_name,
+    get_eventhub_entity_name,
+    get_eventhub_consumer_name,
+)
 from takeoff.context import Context, ContextKey
 from takeoff.credentials.secret import Secret
 from takeoff.schemas import TAKEOFF_BASE_SCHEMA
@@ -116,7 +121,7 @@ class ConfigureEventHub(Step):
                     get_eventhub_name(self.config, self.env),
                     get_eventhub_entity_name(group["eventhub_entity_naming"], self.env),
                 ),
-                group["consumer_group"],
+                get_eventhub_consumer_name(group["consumer_group"], self.env),
                 group["create_databricks_secret"],
             )
             for group in self.config["create_consumer_groups"]

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -199,10 +199,6 @@ class DeployToDatabricks(Step):
 
     def _run_job(self, job_id: str):
         resp = self.jobs_api.run_now(
-            job_id=job_id,
-            jar_params=None,
-            notebook_params=None,
-            python_params=None,
-            spark_submit_params=None,
+            job_id=job_id, jar_params=None, notebook_params=None, python_params=None, spark_submit_params=None
         )
         logger.info(f"Created run with ID {resp['run_id']}")

--- a/takeoff/azure/util.py
+++ b/takeoff/azure/util.py
@@ -115,6 +115,24 @@ def get_eventhub_entity_name(eventhub_entity_naming: str, env: ApplicationVersio
     return f(eventhub_entity_naming, env)
 
 
+def get_eventhub_consumer_name(eventhub_consumer_naming: str, env: ApplicationVersion) -> str:
+    """Returns the EventHub entity name
+
+    If no plugin is provided this uses the default naming convention (as specified in
+    the `.takeoff/deployment.yml`) and resolves the `{env}` parameter based on the ApplicationVersion.
+
+    Args:
+        str: The eventhub consumer naming convention
+        env: The application version
+    """
+
+    def _format(naming: str, env: ApplicationVersion) -> str:
+        return naming.format(env=env.environment_formatted)
+
+    f = _get_naming_function("get_eventhub_consumer_name", default=_format)
+    return f(eventhub_consumer_naming, env)
+
+
 def get_kubernetes_name(config: dict, env: ApplicationVersion) -> str:
     """Returns the Kubernetes service name
 

--- a/tests/azure/test_util.py
+++ b/tests/azure/test_util.py
@@ -89,6 +89,11 @@ def test_get_default_eventhub_entity_name():
     assert res == "Michaeldev"
 
 
+def test_get_default_eventhub_consumer_name():
+    res = victim.get_eventhub_consumer_name("{env}ilish", ENV)
+    assert res == "devilish"
+
+
 @mock.patch("takeoff.util.DEFAULT_TAKEOFF_PLUGIN_PREFIX", "_takeoff_")
 def test_get_custom_eventhub_entity_name():
     paths = [os.path.dirname(os.path.realpath(__file__))]


### PR DESCRIPTION
## Summary:

When creating an eventhub consumer group it was not possible to use `{env}` in the name. This PR added that functionality.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR
