### PR TITLE
Optional setuppy path to build artifact

### DIFF
--- a/docs/_deployment-steps/build_artifact.md
+++ b/docs/_deployment-steps/build_artifact.md
@@ -24,6 +24,7 @@ Add the following task to ``deployment.yaml``:
 | ----- | ----------- |
 | `task` | `"build_artifact"`
 | `build_tool` | The language identifier of your project | One of `python`, `sbt`
+| `python_setup_path`[optional] | Relative path to setup.py file, including the filename | By default `setup.py`
 
 ### Building Python wheels
 Takeoff will use your `setup.py` to build the python wheel. Therefore, it assumes this `setup.py` is valid and contains all necessary dependencies. As with other steps, Takeoff manages the version number used, based on the git branch/tag for which the CI build is taking place. In this case, you should have a file `version.py` in the root of your project, that contains:

--- a/takeoff/build_artifact.py
+++ b/takeoff/build_artifact.py
@@ -14,6 +14,13 @@ SCHEMA = TAKEOFF_BASE_SCHEMA.extend(
     {
         vol.Required("task"): "build_artifact",
         vol.Required("build_tool"): vol.All(str, vol.In(["python", "sbt"])),
+        vol.Optional(
+            "python_setup_path",
+            default="setup.py",
+            description=(
+                "The relative path of your setup.py file"
+            ),
+        ): str
     },
     extra=vol.ALLOW_EXTRA,
 )
@@ -57,8 +64,7 @@ class BuildArtifact(Step):
         """
         self._write_version()
         self._remove_old_artifacts("dist/")
-
-        cmd = ["python", "setup.py", "bdist_wheel"]
+        cmd = ["python", self.config["python_setup_path"], "bdist_wheel"]
         return_code, _ = run_shell_command(cmd)
 
         if return_code != 0:


### PR DESCRIPTION
build_artifact now has an optional parameter to specify relative path of setup.py when using `build_tool="python"`

## Summary:

Build_artifact always assumes setup.py in the root folder. In some projects we may place the setup.py under `src/setup.py` instead. An optional parameter like this will allow this, hopefully without affecting anyone else because the default value stays equal.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.
  - [X] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated
