### PR TITLE
Fix Databricks job removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH=$PATH:$JAVA_HOME/bin
 ## SBT
 RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
 RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
-RUN apt-get install -y sbt
+RUN apt-get update && apt-get install -y sbt
 
 ## Docker
 RUN apt-get install -y \

--- a/docs/_deployment-steps/deploy_to_databricks.md
+++ b/docs/_deployment-steps/deploy_to_databricks.md
@@ -156,3 +156,9 @@ and these `takeoff_common` keys:
   artifacts_shared_blob_container_name: libraries
   ```
 
+## Removal of old jobs
+The `deploy_to_databricks` step will try to remove any existing jobs whose name matches with the new one it is deploying. There are few things to note here:
+1. If you change the job name (e.g. add/remove/update the `name` field in the deployment config) Takeoff will not recognise the existing job as being the same. It will therefore not remove it.
+2. When running Takeoff on a git tag, you obviously also will be changing the name of the job. For example, if you had version 1.0.0 running before, you now deployed 1.1.0, Takeoff will look for job 1.1.0 to kill, won't find it, and will leave version 1.0.0 running along with your new job 1.1.0.
+3. Takeoff will **not** remove your Databricks job if/when you close your branch (either by removing the branch or by merging a Pull/Merge Request).
+

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup_dependencies = [
     "azure==4.0.0",
     "databricks-cli==0.9.0",
     "docker==4.0.2",
-    "flake8==3.7.2",
     "gitpython==3.1.1",
     "jinja2==2.10.1",
     "kubernetes==10.0.1",

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -84,13 +84,12 @@ class DeployToDatabricks(Step):
         """
         for job in self.config["jobs"]:
             app_name = self._construct_name(job["name"])
-            job_name = f"{app_name}-{self.env.artifact_tag}"
-            job_config = self.create_config(job_name, job)
+            job_config = self.create_config(app_name, job)
             is_streaming = self._job_is_unscheduled(job_config) and not job["is_batch"]
             run_stream_job_immediately = job["run_stream_job_immediately"]
 
             logger.info("Removing old job")
-            self.remove_job(job_config=job, is_streaming=is_streaming)
+            self.remove_job(app_name, is_streaming=is_streaming)
 
             logger.info("Submitting new job with configuration:")
             logger.info(pprint.pformat(job_config))
@@ -136,7 +135,7 @@ class DeployToDatabricks(Step):
 
     def _construct_name(self, name: str) -> str:
         postfix = f"-{name}" if name else ""
-        return f"{self.application_name}{postfix}"
+        return f"{self.application_name}{postfix}-{self.env.artifact_tag}"
 
     @staticmethod
     def _construct_arguments(args: List[dict]) -> list:
@@ -151,7 +150,7 @@ class DeployToDatabricks(Step):
     def _construct_job_config(config_file: str, **kwargs) -> dict:
         return util.render_file_with_jinja(config_file, kwargs, json.loads)
 
-    def remove_job(self, job_config: dict, is_streaming: bool):
+    def remove_job(self, job_name: str, is_streaming: bool):
         """
         Removes the existing job and cancels any running job_run if the application is streaming.
         If the application is batch, it'll let the batch job finish but it will remove the job,
@@ -161,7 +160,7 @@ class DeployToDatabricks(Step):
         job_configs = [
             JobConfig(_["settings"]["name"], _["job_id"]) for _ in self.jobs_api.list_jobs()["jobs"]
         ]
-        job_ids = self._application_job_id(self._construct_name(job_config["name"]), job_configs)
+        job_ids = self._application_job_id(job_name, job_configs)
 
         if not job_ids:
             logger.info(f"Could not find jobs in list of {pprint.pformat(job_configs)}")
@@ -173,9 +172,8 @@ class DeployToDatabricks(Step):
             logger.info(f"Deleting Job with ID {job_id}")
             self.jobs_api.delete_job(job_id)
 
-    def _application_job_id(self, application_name: str, jobs: List[JobConfig]) -> List[int]:
-        pattern = re.compile(rf"^({application_name})-({self.env.artifact_tag})$")
-        return [_.job_id for _ in jobs if has_prefix_match(_.name, application_name, pattern)]
+    def _application_job_id(self, job_name: str, jobs: List[JobConfig]) -> List[int]:
+        return [_.job_id for _ in jobs if job_name in _.name]
 
     def _kill_it_with_fire(self, job_id: int):
         logger.info(f"Finding runs for job_id {job_id}")

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import pprint
-import re
 from dataclasses import dataclass
 from typing import List, Optional, Dict
 
@@ -15,7 +14,7 @@ from takeoff.azure.credentials.databricks import Databricks
 from takeoff.azure.credentials.keyvault import KeyVaultClient
 from takeoff.schemas import TAKEOFF_BASE_SCHEMA
 from takeoff.step import Step
-from takeoff.util import has_prefix_match, get_whl_name, get_main_py_name
+from takeoff.util import get_whl_name, get_main_py_name
 
 logger = logging.getLogger(__name__)
 

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -576,9 +576,8 @@ class TestDeployToDatabricks(object):
                 ) as submit_mock:
                     victim.deploy_to_databricks()
 
-        # TODO: make called_with
-        remove_mock.assert_called_once()
-        submit_mock.assert_called_once()
+        remove_mock.assert_called_once_with("my_app-SNAPSHOT", is_streaming=True)
+        submit_mock.assert_called_once_with(job_config)
 
     @mock.patch.dict(os.environ, TEST_ENV_VARS)
     @mock.patch(
@@ -587,7 +586,6 @@ class TestDeployToDatabricks(object):
     def test_deploy_to_databricks_custom_name(self, _, victim):
         CUSTOM_CONF = {"task": "deploy_to_databricks", "jobs": [{"main_name": "Dave", "name": "baboon-job"}]}
         victim.config = victim.validate({**takeoff_config(), **CUSTOM_CONF})
-        # victim.validate({**takeoff_config(), **BASE_CONF})# "jobs": []}
 
         job_config = {
             "new_cluster": {
@@ -623,7 +621,7 @@ class TestDeployToDatabricks(object):
                     victim.deploy_to_databricks()
 
         remove_mock.assert_called_once_with("my_app-baboon-job-SNAPSHOT", is_streaming=True)
-        submit_mock.assert_called_once()
+        submit_mock.assert_called_once_with(job_config)
 
     @mock.patch.dict(os.environ, TEST_ENV_VARS)
     @mock.patch(

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -17,7 +17,7 @@ jobs = [
     JobConfig("daniel-branch-name", 5),
     JobConfig("tim-postfix-SNAPSHOT", 6),
     JobConfig("tim-postfix-SNAPSHOT", 7),
-    JobConfig("michel-1.2.3--my-version-postfix", 8),
+    JobConfig("michel-1.2.3--my-version-postfix", 8)
 ]
 
 streaming_job_config = "tests/azure/files/test_job_config.json.j2"
@@ -79,38 +79,38 @@ class TestDeployToDatabricks(object):
         assert victim.config["jobs"][0]["lang"] == "python"
         assert victim.config["jobs"][0]["arguments"] == [{}]
 
-    def test_find_application_job_id_if_snapshot(self, victim):
-        victim.env = ApplicationVersion('ACP', 'SNAPSHOT', 'master')
-        assert victim._application_job_id("foo", jobs) == [1]
+    def test_find_application_id_exact_match(self, victim):
+        assert victim._application_job_id("foo-SNAPSHOT", jobs) == [1]
 
-    def test_find_application_job_id_if_version(self, victim):
-        victim.env = ApplicationVersion('PRD', '0.3.1', 'tag')
-        assert victim._application_job_id("bar", jobs) == [2]
+    def test_find_application_id_no_match(self, victim):
+        assert victim._application_job_id("NO_FIND_ME", jobs) == []
 
-    def test_find_application_job_id_if_version_not_set(self, victim):
-        victim.env = ApplicationVersion('PRD', '', 'tag')
-        assert victim._application_job_id("bar", jobs) == []
-
-    def test_find_application_job_id_if_branch(self, victim):
-        victim.env = ApplicationVersion('DEV', 'branch-name', 'branch')
-        assert victim._application_job_id("daniel", jobs) == [5]
-
-    def test_find_application_job_id_if_branch_if_no_version(self, victim):
-        victim.env = ApplicationVersion('DEV', '', 'branch')
-        assert victim._application_job_id("daniel", jobs) == []
-
-    def test_find_application_job_id_if_postfix(self, victim):
-        victim.env = ApplicationVersion('DEV', 'SNAPSHOT', 'master')
+    def test_find_application_id_multiple_matches(self, victim):
         assert victim._application_job_id("tim-postfix", jobs) == [6, 7]
 
-    def test_find_application_job_id_if_version_postfix(self, victim):
-        victim.env = ApplicationVersion('PRD', '1.2.3--my-version-postfix', 'branch')
-        assert victim._application_job_id("michel", jobs) == [8]
+    def test_construct_name_tag(self, victim):
+        victim.env = ApplicationVersion('PRD', '1.2.3', 'tag')
+        assert victim._construct_name("") == "my_app-1.2.3"
 
-    def test_construct_name(self, victim):
-        assert victim._construct_name("") == "my_app"
-        assert victim._construct_name("foo") == "my_app-foo"
+    def test_construct_name_tag_job_name_set(self, victim):
+        victim.env = ApplicationVersion('PRD', '1.2.3', 'tag')
+        assert victim._construct_name("foo") == "my_app-foo-1.2.3"
 
+    def test_construct_name_snapshot(self, victim):
+        victim.env = ApplicationVersion('ACP', 'SNAPSHOT', 'master')
+        assert victim._construct_name("") == "my_app-SNAPSHOT"
+
+    def test_construct_name_snapshot_job_name_set(self, victim):
+        victim.env = ApplicationVersion('ACP', 'SNAPSHOT', 'master')
+        assert victim._construct_name("foo") == "my_app-foo-SNAPSHOT"
+
+    def test_construct_name_branch(self, victim):
+        victim.env = ApplicationVersion('DEV', 'my-branch', 'my-epic-branch')
+        assert victim._construct_name("") == "my_app-my-branch"
+
+    def test_construct_name_branch_job_name_set(self, victim):
+        victim.env = ApplicationVersion('DEV', 'my-branch', 'my-epic-branch')
+        assert victim._construct_name("foo") == "my_app-foo-my-branch"
 
     def test_job_is_unscheduled(self, victim):
         job_config = victim._construct_job_config(config_file=streaming_job_config)
@@ -578,6 +578,51 @@ class TestDeployToDatabricks(object):
 
         # TODO: make called_with
         remove_mock.assert_called_once()
+        submit_mock.assert_called_once()
+
+    @mock.patch.dict(os.environ, TEST_ENV_VARS)
+    @mock.patch(
+        "takeoff.step.KeyVaultClient.vault_and_client", return_value=(None, None)
+    )
+    def test_deploy_to_databricks_custom_name(self, _, victim):
+        CUSTOM_CONF = {"task": "deploy_to_databricks", "jobs": [{"main_name": "Dave", "name": "baboon-job"}]}
+        victim.config = victim.validate({**takeoff_config(), **CUSTOM_CONF})
+        # victim.validate({**takeoff_config(), **BASE_CONF})# "jobs": []}
+
+        job_config = {
+            "new_cluster": {
+                "spark_version": "4.1.x-scala2.11",
+                "spark_conf": {
+                    "spark.sql.warehouse.dir": "/some_",
+                    "some.setting": "true",
+                },
+                "cluster_log_conf": {
+                    "dbfs": {"destination": "dbfs:/mnt/sdh/logs/job_with_schedule"}
+                },
+            },
+            "name": "job_with_schedule",
+            "libraries": [
+                {"whl": "dbfs:/mnt/libraries/version/version-bar-py3-none-any.whl"},
+                {"jar": "some.jar"}
+            ],
+            "spark_python_task": {
+                "python_file": "dbfs:/mnt/libraries/version/version-main-bar.py",
+                "parameters": ["--key", "val", "--key2", "val2"]
+            }
+        }
+        with mock.patch(
+                "takeoff.azure.deploy_to_databricks.DeployToDatabricks.create_config",
+                return_value=job_config,
+        ) as config_mock:
+            with mock.patch(
+                    "takeoff.azure.deploy_to_databricks.DeployToDatabricks.remove_job"
+            ) as remove_mock:
+                with mock.patch(
+                        "takeoff.azure.deploy_to_databricks.DeployToDatabricks._submit_job"
+                ) as submit_mock:
+                    victim.deploy_to_databricks()
+
+        remove_mock.assert_called_once_with("my_app-baboon-job-SNAPSHOT", is_streaming=True)
         submit_mock.assert_called_once()
 
     @mock.patch.dict(os.environ, TEST_ENV_VARS)


### PR DESCRIPTION
## Summary:

The existing job removal of existing Databricks jobs was problematic. Specifically, it didn't work at all if you specified a name in the `deployment.yml` Takeoff step. This PR simplifies the matching used to ensure that removing old jobs works both with and without a specific name being set. 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
