### PR TITLE
publish_artifact adds the original filename to the end of the python file

### DIFF
--- a/docs/_deployment-steps/publish_artifact.md
+++ b/docs/_deployment-steps/publish_artifact.md
@@ -11,7 +11,7 @@ category: Artifacts
 # Publish Artifacts
 
 This step allows you to publish artifacts for different languages to different targets:
-- You can publish Python wheels to cloud storage, or to PyPi.
+- You can publish Python files and wheels to cloud storage, or to PyPi.
 - You can publish Scala jars to cloud storage, or to Ivy
 
 <p class='note warning'>
@@ -20,6 +20,12 @@ This step allows you to publish artifacts for different languages to different t
 
 <p class='note warning'>
   Regarding Scala, only SBT is supported as build tool
+</p>
+
+<p class='note warning'>
+  If `"publish_artifact"` is used multiple times for publishing Python files, the same artifact name is used, therefore overwriting each previous published artifact task.
+  In this case set the '"use_original_python_filename"' to include the python filename from `"python_file_path"` in the artifact name.
+  This will not help if the `"python_file_path"` is the same filename.
 </p>
 
 ## Deployment
@@ -32,6 +38,7 @@ Add the following task to ``deployment.yaml``
 | `language` | The language identifier of your project | One of `python`, `scala`
 | `target` | List of targets to push the artifact to. For Python these can be: `cloud_storage`, `pypi`. For Scala artifacts these can be: `cloud_storage`, `ivy`
 | `python_file_path` [optional] | The path relative to the root of your project to the python script that serves as entrypoint for a databricks job 
+| `use_original_python_filename` [optional] | Use this flag to keep the original filename as part of the artifact name. Only impacts Python files.
 
 For all languages, the assumption is that the artifact has already been built, for example by the `build_artifact` step that Takeoff offers.
 

--- a/docs/_deployment-steps/publish_artifact.md
+++ b/docs/_deployment-steps/publish_artifact.md
@@ -23,9 +23,8 @@ This step allows you to publish artifacts for different languages to different t
 </p>
 
 <p class='note warning'>
-  If `"publish_artifact"` is used multiple times for publishing Python files, the same artifact name is used, therefore overwriting each previous published artifact task.
-  In this case set the '"use_original_python_filename"' to include the python filename from `"python_file_path"` in the artifact name.
-  This will not help if the `"python_file_path"` is the same filename.
+  When uploading multiple Python files, make sure to set the `"use_original_python_filename"` flag to differentiate between the different Python files.
+  By default a fixed name for the Python file is used, which in this case will cause files to be overwritten.
 </p>
 
 ## Deployment
@@ -38,7 +37,7 @@ Add the following task to ``deployment.yaml``
 | `language` | The language identifier of your project | One of `python`, `scala`
 | `target` | List of targets to push the artifact to. For Python these can be: `cloud_storage`, `pypi`. For Scala artifacts these can be: `cloud_storage`, `ivy`
 | `python_file_path` [optional] | The path relative to the root of your project to the python script that serves as entrypoint for a databricks job 
-| `use_original_python_filename` [optional] | Use this flag to keep the original filename as part of the artifact name. Only impacts Python files.
+| `use_original_python_filename` [optional] | If you upload multiple unique Python files use this flag to include the original filename in the result. Only impacts Python files.
 
 For all languages, the assumption is that the artifact has already been built, for example by the `build_artifact` step that Takeoff offers.
 

--- a/takeoff/azure/create_application_insights.py
+++ b/takeoff/azure/create_application_insights.py
@@ -86,8 +86,7 @@ class CreateApplicationInsights(Step):
         credentials = get_azure_credentials_object(self.config, self.vault_name, self.vault_client)
 
         return ApplicationInsightsManagementClient(
-            credentials,
-            SubscriptionId(self.vault_name, self.vault_client).subscription_id(self.config),
+            credentials, SubscriptionId(self.vault_name, self.vault_client).subscription_id(self.config),
         )
 
     def _find_existing_instance(

--- a/takeoff/azure/create_application_insights.py
+++ b/takeoff/azure/create_application_insights.py
@@ -86,7 +86,8 @@ class CreateApplicationInsights(Step):
         credentials = get_azure_credentials_object(self.config, self.vault_name, self.vault_client)
 
         return ApplicationInsightsManagementClient(
-            credentials, SubscriptionId(self.vault_name, self.vault_client).subscription_id(self.config),
+            credentials,
+            SubscriptionId(self.vault_name, self.vault_client).subscription_id(self.config),
         )
 
     def _find_existing_instance(

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -110,7 +110,7 @@ class DeployToDatabricks(Step):
 
         if job_config["lang"] == "python":
             wheel_name = get_whl_name(self.application_name, self.env.artifact_tag, ".whl")
-            py_main_name = get_main_py_name(self.application_name, self.env.artifact_tag, ".py")
+            py_main_name = get_main_py_name(self.application_name, self.env.artifact_tag, job_config["main_name"])
             run_config = DeployToDatabricks._construct_job_config(
                 **common_arguments,
                 whl_file=f"{root_library_folder}/{wheel_name}",

--- a/takeoff/azure/deploy_to_databricks.py
+++ b/takeoff/azure/deploy_to_databricks.py
@@ -110,7 +110,9 @@ class DeployToDatabricks(Step):
 
         if job_config["lang"] == "python":
             wheel_name = get_whl_name(self.application_name, self.env.artifact_tag, ".whl")
-            py_main_name = get_main_py_name(self.application_name, self.env.artifact_tag, job_config["main_name"])
+            py_main_name = get_main_py_name(
+                self.application_name, self.env.artifact_tag, job_config["main_name"]
+            )
             run_config = DeployToDatabricks._construct_job_config(
                 **common_arguments,
                 whl_file=f"{root_library_folder}/{wheel_name}",

--- a/takeoff/azure/publish_artifact.py
+++ b/takeoff/azure/publish_artifact.py
@@ -47,6 +47,14 @@ SCHEMA = vol.All(
                         "that serves as entrypoint for a databricks job"
                     ),
                 ): str,
+                vol.Optional(
+                    "use_original_python_filename",
+                    description=(
+                        "If you upload multiple python files, they are overwritten by each other."
+                        "Use this flag to use the original filename to create unique python files."
+                    ),
+                    default=False,
+                ): bool,
                 "azure": vol.All(
                     {
                         "common": {
@@ -156,7 +164,12 @@ class PublishArtifact(Step):
         blob_service = BlobStore(self.vault_name, self.vault_client).service_client(self.config)
 
         if file_extension == ".py":
-            filename = get_main_py_name(self.application_name, self.env.artifact_tag, file)
+            filename = get_main_py_name(
+                self.application_name,
+                self.env.artifact_tag,
+                file,
+                self.config["use_original_python_filename"],
+            )
         elif file_extension == ".whl":
             filename = get_whl_name(self.application_name, self.env.artifact_tag, file_extension)
         elif file_extension == ".jar":

--- a/takeoff/azure/publish_artifact.py
+++ b/takeoff/azure/publish_artifact.py
@@ -50,8 +50,8 @@ SCHEMA = vol.All(
                 vol.Optional(
                     "use_original_python_filename",
                     description=(
-                        "If you upload multiple python files, they are overwritten by each other."
-                        "Use this flag to use the original filename to create unique python files."
+                        "If you upload multiple unique Python files use this flag to include the original."
+                        "filename in the result. Only impacts Python files."
                     ),
                     default=False,
                 ): bool,

--- a/takeoff/azure/publish_artifact.py
+++ b/takeoff/azure/publish_artifact.py
@@ -156,7 +156,7 @@ class PublishArtifact(Step):
         blob_service = BlobStore(self.vault_name, self.vault_client).service_client(self.config)
 
         if file_extension == ".py":
-            filename = get_main_py_name(self.application_name, self.env.artifact_tag, file_extension)
+            filename = get_main_py_name(self.application_name, self.env.artifact_tag, file)
         elif file_extension == ".whl":
             filename = get_whl_name(self.application_name, self.env.artifact_tag, file_extension)
         elif file_extension == ".jar":

--- a/takeoff/util.py
+++ b/takeoff/util.py
@@ -183,10 +183,21 @@ def get_whl_name(build_definition_name: str, artifact_tag: str, file_ext: str) -
     )
 
 
-def get_main_py_name(build_definition_name: str, artifact_tag: str, file_path: str) -> str:
+def get_main_py_name(
+    build_definition_name: str,
+    artifact_tag: str,
+    file_path: str,
+    use_original_python_filename: Optional[bool] = False,
+) -> str:
+    if use_original_python_filename:
+        return (
+            f"{build_definition_name}/{build_definition_name.replace('-', '_')}-"
+            f"main-{artifact_tag.replace('-', '_')}-{os.path.basename(file_path)}"
+        )
+
     return (
         f"{build_definition_name}/{build_definition_name.replace('-', '_')}-"
-        f"main-{artifact_tag.replace('-', '_')}-{os.path.basename(file_path)}"
+        f"main-{artifact_tag.replace('-', '_')}.py"
     )
 
 

--- a/takeoff/util.py
+++ b/takeoff/util.py
@@ -131,7 +131,7 @@ def get_matching_group(find_in: str, pattern: Pattern[str], group: int):
     match = pattern.search(find_in)
 
     if not match:
-        raise ValueError(f"Couldn't find a match")
+        raise ValueError("Couldn't find a match")
 
     found_groups = len(match.groups())
     if found_groups < group:

--- a/takeoff/util.py
+++ b/takeoff/util.py
@@ -183,10 +183,10 @@ def get_whl_name(build_definition_name: str, artifact_tag: str, file_ext: str) -
     )
 
 
-def get_main_py_name(build_definition_name: str, artifact_tag: str, file_ext: str) -> str:
+def get_main_py_name(build_definition_name: str, artifact_tag: str, file_path: str) -> str:
     return (
         f"{build_definition_name}/{build_definition_name.replace('-', '_')}-"
-        f"main-{artifact_tag.replace('-', '_')}{file_ext}"
+        f"main-{artifact_tag.replace('-', '_')}-{os.path.basename(file_path)}"
     )
 
 

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -380,7 +380,7 @@ class TestDeployToDatabricks(object):
                 "timezone_id": "America/Los_Angeles",
             },
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }
@@ -424,7 +424,7 @@ class TestDeployToDatabricks(object):
                 "timezone_id": "America/Los_Angeles",
             },
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }
@@ -464,7 +464,7 @@ class TestDeployToDatabricks(object):
                 {"jar": "some.jar"}
             ],
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }
@@ -496,7 +496,7 @@ class TestDeployToDatabricks(object):
                 {"jar": "some.jar"}
             ],
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }
@@ -533,7 +533,7 @@ class TestDeployToDatabricks(object):
                 "timezone_id": "America/Los_Angeles",
             },
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -380,7 +380,7 @@ class TestDeployToDatabricks(object):
                 "timezone_id": "America/Los_Angeles",
             },
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }
@@ -424,7 +424,7 @@ class TestDeployToDatabricks(object):
                 "timezone_id": "America/Los_Angeles",
             },
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }
@@ -464,7 +464,7 @@ class TestDeployToDatabricks(object):
                 {"jar": "some.jar"}
             ],
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }
@@ -496,7 +496,7 @@ class TestDeployToDatabricks(object):
                 {"jar": "some.jar"}
             ],
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }
@@ -533,7 +533,7 @@ class TestDeployToDatabricks(object):
                 "timezone_id": "America/Los_Angeles",
             },
             "spark_python_task": {
-                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT-some.py",
+                "python_file": "dbfs:/mnt/libraries/my_app/my_app-main-SNAPSHOT.py",
                 "parameters": ["--key", "val", "--key2", "val2"]
             }
         }

--- a/tests/azure/test_deploy_to_databricks.py
+++ b/tests/azure/test_deploy_to_databricks.py
@@ -347,7 +347,7 @@ class TestDeployToDatabricks(object):
 
     def test_correct_schedule_as_parameter_in_job_config_without_env(self, victim):
         conf = {
-            "main_name": "some.py",
+            "main_name": "my_app/src/some.py",
             "config_file": dynamic_schedule_job_config,
             "lang": "python",
             "arguments": [{"key": "val"}, {"key2": "val2"}],

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -74,3 +74,13 @@ def test_ensure_base64_non_encoded():
 def test_ensure_base64_encoded():
     result = victim.ensure_base64("c29tZXRoaW5n")
     assert result == "c29tZXRoaW5n"
+
+
+def test_get_main_py_name():
+    result = victim.get_main_py_name("project-name", "my-branch", "my_app/src/some.py")
+    assert result == "project-name/project_name-main-my_branch.py"
+
+
+def test_get_main_py_name_with_original_filename():
+    result = victim.get_main_py_name("project-name", "my-branch", "my_app/src/some.py", True)
+    assert result == "project-name/project_name-main-my_branch-some.py"


### PR DESCRIPTION
## Summary:

Takeoff was using the same destination filename foreach `publish_artifact` for language `python`. In case you need to upload multiple python file to your cloud storage, you ended up with only one file.

This MR changes the destination filename for `publish_artifact`, for python, to the cloud by adding the original filename. This will prevent that each `publish_artifact` overwrites the previous one.

## Breaking Change:

None

## Checklist:
  - [x] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.
  - [X] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated
