### PR TITLE
Put docker image on a diet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.8
+FROM python:3.8-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl
+RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg2
 
 ## Java
-RUN apt-get install -y openjdk-11-jdk
+RUN mkdir -p /usr/share/man/man1 && apt-get install -y openjdk-11-jre-headless && rm -rf /usr/share/man/man1
 ENV JAVA_HOME=/usr/lib/openjdk-11
 ENV PATH=$PATH:$JAVA_HOME/bin
 


### PR DESCRIPTION
The Takeoff docker image was getting rather fat. I put it on a  diet.

Image size before: 2.28Gb
Image size after: 1.21Gb

Size reduction achieved by:
- moving to slim base image
- using jre instead of jdk

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] There are no new TODOs in this PR

If exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated
